### PR TITLE
Remove admin permissions requirements

### DIFF
--- a/workflow-templates/appstore-build-publish.yml
+++ b/workflow-templates/appstore-build-publish.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Check actor permission
         uses: skjnldsv/check-actor-permission@v2
         with:
-          require: admin
+          require: write
 
       - name: Set app env
         run: |


### PR DESCRIPTION
Since we enforce running on https://github.com/nextcloud-releases, no need for admin, Just set your team rights to `write`