### PR TITLE
Add a global CONTRIBUTING.md and SECURITY.md for all orga repos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,59 @@
+## Submitting issues
+
+If you have questions about how to install or use Nextcloud, please direct these to our [forum][forum].
+
+### Guidelines
+* Please search the existing issues first, it's likely that your issue was already reported or even fixed.
+  - Go to one of the repositories, click "issues" and type any word in the top search/command bar.
+  - More info on [search syntax within github](https://help.github.com/articles/searching-issues)
+* __SECURITY__: Report any potential security bug to us via [our HackerOne page](https://hackerone.com/nextcloud) following our [security policy](https://nextcloud.com/security/) instead of filing an issue in our bug tracker.
+* The issues in other components should be reported in their respective repositories: You will find them in our [GitHub Organization](https://github.com/nextcloud/)
+* Report the issue using one of our templates, they include all the information we need to track down the issue.
+
+Help us to maximize the effort we can spend fixing issues and adding new features, by not reporting duplicate issues.
+
+[forum]: https://help.nextcloud.com/
+
+## Contributing to Source Code
+
+Thanks for wanting to contribute source code to Nextcloud. That's great!
+
+Please read the [Developer Manuals][devmanual] to learn how to create your first application or how to test the Nextcloud code.
+
+### Tests
+
+In order to constantly increase the quality of our software we can no longer accept pull request which submit un-tested code.
+It is a must have that changed and added code segments are unit tested.
+In some areas unit testing is hard (aka almost impossible) as of today - in these areas refactoring WHILE fixing a bug is encouraged to enable unit testing.
+
+### Sign your work
+
+We use the Developer Certificate of Origin (DCO) as a additional safeguard
+for the Nextcloud project. This is a well established and widely used
+mechanism to assure contributors have confirmed their right to license
+their contribution under the project's license.
+Please read [contribute/developer-certificate-of-origin][dcofile].
+If you can certify it, then just add a line to every git commit message:
+
+````
+  Signed-off-by: Random J Developer <random@developer.example.org>
+````
+
+Use your real name (sorry, no pseudonyms or anonymous contributions).
+If you set your `user.name` and `user.email` git configs, you can sign your
+commit automatically with `git commit -s`. You can also use git [aliases](https://git-scm.com/book/tr/v2/Git-Basics-Git-Aliases)
+like `git config --global alias.ci 'commit -s'`. Now you can commit with
+`git ci` and the commit will be signed.
+
+### Apply a license
+
+In case you are not sure how to add or update the license header correctly please have a look at [contribute/HowToApplyALicense.md][applyalicense]
+
+[devmanual]: https://docs.nextcloud.com/server/latest/developer_manual/
+[dcofile]: https://github.com/nextcloud/server/blob/master/contribute/developer-certificate-of-origin
+[applyalicense]: https://github.com/nextcloud/server/blob/master/contribute/HowToApplyALicense.md
+
+## Translations
+Please submit translations via [Transifex][transifex].
+
+[transifex]: https://www.transifex.com/nextcloud

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,6 +16,7 @@ Your report should include:
 - Reproduction steps
 
 If in scope of the project a member of the security team will confirm the vulnerability, determine its impact, and develop a fix.
+Otherwise the team will contact the maintainer and make sure the issue gets fixed.
 The fix will be applied to the master branch, tested, and packaged in the next security release.
 The vulnerability will be publicly announced after the release. Finally, your name will be added
 to the [hall of fame](https://hackerone.com/nextcloud/thanks) as a thank you from the entire Nextcloud community. Note our

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,25 @@
+# Security Policy
+
+## Supported Versions
+
+The latest three major release versions of Nextcloud are currently being supported with security updates.
+Please visit https://github.com/nextcloud/server/wiki/Maintenance-and-Release-Schedule for further details.
+
+## Reporting a Vulnerability
+
+Security is very important to us. If you have discovered a security issue with Nextcloud,
+please read our responsible disclosure guidelines and contact us at [hackerone.com/nextcloud](https://hackerone.com/nextcloud).
+Your report should include:
+
+- Product version
+- A vulnerability description
+- Reproduction steps
+
+If in scope of the project a member of the security team will confirm the vulnerability, determine its impact, and develop a fix.
+The fix will be applied to the master branch, tested, and packaged in the next security release.
+The vulnerability will be publicly announced after the release. Finally, your name will be added
+to the [hall of fame](https://hackerone.com/nextcloud/thanks) as a thank you from the entire Nextcloud community. Note our
+[threat model](https://nextcloud.com/security/threat-model) to know what is expected behavior.
+
+
+Please visit https://nextcloud.com/security/ for further information about security.


### PR DESCRIPTION
Fixes https://github.com/nextcloud/.github/issues/31

This is a copy of the CONTRIBUTING.md from server with two changes

* Dropped the dead IRC channel
* Dropped links to the server-specific issue template. Each repo has its own
* Dropped ref to server repo
* Minor adjustments

SECURITY.md was copied as is.