### PR TITLE
Add summary to the php-lint action

### DIFF
--- a/workflow-templates/lint-php.yml
+++ b/workflow-templates/lint-php.yml
@@ -13,13 +13,13 @@ on:
       - stable*
 
 jobs:
-  lint:
+  php-lint:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         php-versions: ["7.3", "7.4", "8.0"]
 
-    name: php
+    name: php-lint
 
     steps:
       - name: Checkout
@@ -33,3 +33,15 @@ jobs:
 
       - name: Lint
         run: composer run lint
+
+  summary:
+    runs-on: ubuntu-latest
+    needs: php-lint
+
+    if: always()
+
+    name: php-lint-summary
+
+    steps:
+      - name: Summary status
+        run: if ${{ needs.php-lint.result != 'success' && needs.php-lint.result != 'skipped' }}; then exit 1; fi


### PR DESCRIPTION
That way we can only add the summary as a "required check" in the branch protection, making iteasier to support the same tests across multiple stable branches.
What do you think? :thinking: 

I think we should maybe push that forward a bit more, easier to update the master php supported versions for example, without having to touch the branch protections every time? :tada: 