### PR TITLE
Improve UX when node job fails because of assets

### DIFF
--- a/workflow-templates/node.yml
+++ b/workflow-templates/node.yml
@@ -47,10 +47,12 @@ jobs:
 
       - name: Check webpack build changes
         run: |
-          bash -c "[[ ! \"`git status --porcelain `\" ]] || exit 1"
+          bash -c "[[ ! \"`git status --porcelain `\" ]] || (echo 'Please recompile and commit the assets, see the section \"Show changes on failure\" for details' && exit 1)"
 
       - name: Show changes on failure
         if: failure()
         run: |
           git status
           git --no-pager diff
+          exit 1 # make it red to grab attention
+


### PR DESCRIPTION
Adds an explicit message about recompiling to avoid scratching heads.
Also highlight "Show changes on failure" in red so that it catches the
eye because it's easy to miss while scratching head.

Before:
<img width="745" alt="image" src="https://user-images.githubusercontent.com/277525/182603231-7e765124-2fac-4a3d-8263-8194684129bd.png">

After:
<img width="681" alt="image" src="https://user-images.githubusercontent.com/277525/182615860-ae7d3104-3afe-4f53-b416-8bcdba3714b0.png">

Note: I have changed the message since the screenshot, but you get the point.

Background:

This is a follow up on my frustration in https://github.com/nextcloud/recommendations/pull/514#issuecomment-1203860403 as I wasn't aware that asset compilation was required also for this repo because we don't have it elsewhere.