### PR TITLE
Force enable app in CI so that testing master with server master works

### DIFF
--- a/workflow-templates/phpunit-mysql.yml
+++ b/workflow-templates/phpunit-mysql.yml
@@ -100,7 +100,7 @@ jobs:
         run: |
           mkdir data
           ./occ maintenance:install --verbose --database=mysql --database-name=nextcloud --database-host=127.0.0.1 --database-port=$DB_PORT --database-user=root --database-pass=rootpassword --admin-user admin --admin-pass password
-          ./occ app:enable ${{ env.APP_NAME }}
+          ./occ app:enable --force ${{ env.APP_NAME }}
 
       - name: Check PHPUnit config file existence
         id: check_phpunit

--- a/workflow-templates/phpunit-oci.yml
+++ b/workflow-templates/phpunit-oci.yml
@@ -92,7 +92,7 @@ jobs:
         run: |
           mkdir data
           ./occ maintenance:install --verbose --database=oci --database-name=XE --database-host=127.0.0.1 --database-port=$DB_PORT --database-user=autotest --database-pass=owncloud --admin-user admin --admin-pass admin
-          ./occ app:enable ${{ env.APP_NAME }}
+          ./occ app:enable --force ${{ env.APP_NAME }}
 
       - name: Check PHPUnit config file existence
         id: check_phpunit

--- a/workflow-templates/phpunit-pgsql.yml
+++ b/workflow-templates/phpunit-pgsql.yml
@@ -97,7 +97,7 @@ jobs:
         run: |
           mkdir data
           ./occ maintenance:install --verbose --database=pgsql --database-name=nextcloud --database-host=127.0.0.1 --database-port=$DB_PORT --database-user=root --database-pass=rootpassword --admin-user admin --admin-pass password
-          ./occ app:enable ${{ env.APP_NAME }}
+          ./occ app:enable --force ${{ env.APP_NAME }}
 
       - name: Check PHPUnit config file existence
         id: check_phpunit

--- a/workflow-templates/phpunit-sqlite.yml
+++ b/workflow-templates/phpunit-sqlite.yml
@@ -86,7 +86,7 @@ jobs:
         run: |
           mkdir data
           ./occ maintenance:install --verbose --database=sqlite --database-name=nextcloud --database-host=127.0.0.1 --database-port=$DB_PORT --database-user=root --database-pass=rootpassword --admin-user admin --admin-pass password
-          ./occ app:enable ${{ env.APP_NAME }}
+          ./occ app:enable --force ${{ env.APP_NAME }}
 
       - name: Check PHPUnit config file existence
         id: check_phpunit


### PR DESCRIPTION
This avoids having to list server master version number as compatible
 too soon in the application info.xml

Signed-off-by: Côme Chilliet <come.chilliet@nextcloud.com>