### PR TITLE
Lint only PRs, not pushes (or merges)

### DIFF
--- a/.github/workflows/lint-yaml.yml
+++ b/.github/workflows/lint-yaml.yml
@@ -1,10 +1,6 @@
 name: Lint
 
-on:
-  pull_request:
-  push:
-    branches:
-      - master
+on: pull_request
 
 jobs:
   yaml-lint:

--- a/workflow-templates/lint-eslint.yml
+++ b/workflow-templates/lint-eslint.yml
@@ -5,13 +5,7 @@
 
 name: Lint
 
-on:
-  pull_request:
-  push:
-    branches:
-      - main
-      - master
-      - stable*
+on: pull_request
 
 permissions:
   contents: read

--- a/workflow-templates/lint-php-cs.yml
+++ b/workflow-templates/lint-php-cs.yml
@@ -5,13 +5,7 @@
 
 name: Lint
 
-on:
-  pull_request:
-  push:
-    branches:
-      - main
-      - master
-      - stable*
+on: pull_request
 
 permissions:
   contents: read

--- a/workflow-templates/lint-stylelint.yml
+++ b/workflow-templates/lint-stylelint.yml
@@ -5,13 +5,7 @@
 
 name: Lint
 
-on:
-  pull_request:
-  push:
-    branches:
-      - main
-      - master
-      - stable*
+on: pull_request
 
 permissions:
   contents: read


### PR DESCRIPTION
Aint nobody gonna check lint results of a direct push. This is a waste of CI time.