### PR TITLE
Fixate postgres image version

### DIFF
--- a/workflow-templates/phpunit-pgsql.yml
+++ b/workflow-templates/phpunit-pgsql.yml
@@ -48,7 +48,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres
+        image: postgres:14
         ports:
           - 4444:5432/tcp
         env:


### PR DESCRIPTION
We should always fixate the image versions (oracle and mysql have it already). So that CI on stable branches is staying functional with whatever was supported at the time.
* https://github.com/nextcloud/server/issues/34617

All stable23 and stable24 branches in all apps will also need this patch as we will mostlikely not backport the fixes to support a new DB on a stable branch much further then the current one.