### PR TITLE
Remove trailing whitespaces from templates

### DIFF
--- a/workflow-templates/appstore-build-publish.yml
+++ b/workflow-templates/appstore-build-publish.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Set app env
         run: |
-          # Split and keep last 
+          # Split and keep last
           echo "APP_NAME=${GITHUB_REPOSITORY##*/}" >> $GITHUB_ENV
           echo "APP_VERSION=${GITHUB_REF##*/}" >> $GITHUB_ENV
 

--- a/workflow-templates/block-merge-eol.yml
+++ b/workflow-templates/block-merge-eol.yml
@@ -10,7 +10,7 @@ on: pull_request
 permissions:
   contents: read
 
-concurrency: 
+concurrency:
   group: block-merge-eol-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 

--- a/workflow-templates/block-merge-freeze.yml
+++ b/workflow-templates/block-merge-freeze.yml
@@ -10,7 +10,7 @@ on: pull_request
 permissions:
   contents: read
 
-concurrency: 
+concurrency:
   group: block-merge-freeze-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 

--- a/workflow-templates/command-compile.yml
+++ b/workflow-templates/command-compile.yml
@@ -37,7 +37,7 @@ jobs:
       # Init path depending on which command is run
       - name: Init path
         id: git-path
-        run: |    
+        run: |
           if ${{ startsWith(steps.command.outputs.arg1, '/') }}; then
             echo "::set-output name=path::${{ github.workspace }}${{steps.command.outputs.arg1}}"
           else
@@ -47,7 +47,7 @@ jobs:
       - name: Init branch
         uses: xt0rted/pull-request-comment-branch@v1
         id: comment-branch
-    
+
   process:
     runs-on: ubuntu-latest
     needs: init

--- a/workflow-templates/dependabot-approve-merge.yml
+++ b/workflow-templates/dependabot-approve-merge.yml
@@ -15,7 +15,7 @@ on:
 permissions:
   contents: read
 
-concurrency: 
+concurrency:
   group: dependabot-approve-merge-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       # for hmarr/auto-approve-action to approve PRs
-      pull-requests: write 
+      pull-requests: write
 
     steps:
       # Github actions bot approve

--- a/workflow-templates/lint-info-xml.yml
+++ b/workflow-templates/lint-info-xml.yml
@@ -16,7 +16,7 @@ on:
 permissions:
   contents: read
 
-concurrency: 
+concurrency:
   group: lint-info-xml-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 


### PR DESCRIPTION
Should prevent PRs like https://github.com/nextcloud/registration/pull/476 in the future when people already copied the template (as copying removes trailing whitespace in an IDE)

Command used:
```
find . -name "*.yml" -type f -print0 | xargs -0 sed -i 's/[[:space:]]*$//'
```