### PR TITLE
Only check JS compiling and eslint with relevant changes

### DIFF
--- a/workflow-templates/lint-eslint.yml
+++ b/workflow-templates/lint-eslint.yml
@@ -5,7 +5,16 @@
 
 name: Lint
 
-on: pull_request
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - 'src/**'
+      - 'appinfo/info.xml'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'tsconfig.json'
+      - '**.js'
 
 permissions:
   contents: read

--- a/workflow-templates/lint-eslint.yml
+++ b/workflow-templates/lint-eslint.yml
@@ -15,6 +15,8 @@ on:
       - 'package-lock.json'
       - 'tsconfig.json'
       - '**.js'
+      - '**.ts'
+      - '**.vue'
 
 permissions:
   contents: read

--- a/workflow-templates/node.yml
+++ b/workflow-templates/node.yml
@@ -15,6 +15,8 @@ on:
       - 'package-lock.json'
       - 'tsconfig.json'
       - '**.js'
+      - '**.ts'
+      - '**.vue'
   push:
     branches:
       - main

--- a/workflow-templates/node.yml
+++ b/workflow-templates/node.yml
@@ -7,6 +7,14 @@ name: Node
 
 on:
   pull_request:
+    paths:
+      - '.github/workflows/**'
+      - 'src/**'
+      - 'appinfo/info.xml'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'tsconfig.json'
+      - '**.js'
   push:
     branches:
       - main


### PR DESCRIPTION
In some apps like Talk this can free 2 more minutes of CI on every PHP based PR.

Additionally opted in for any js file (configs in root), package* (npm changes), workflow file changes as well as info.xml to run it on release PRs.