### PR TITLE
fix(fixup): Do not run fixup commit check for draft PRs

### DIFF
--- a/workflow-templates/fixup.yml
+++ b/workflow-templates/fixup.yml
@@ -5,7 +5,9 @@
 
 name: Pull request checks
 
-on: pull_request
+on:
+  pull_request:
+    types: [opened, ready_for_review, reopened]
 
 permissions:
   contents: read
@@ -16,6 +18,8 @@ concurrency:
 
 jobs:
   commit-message-check:
+    if: github.event.pull_request.draft == false
+
     permissions:
       pull-requests: write
     name: Block fixup and squash commits


### PR DESCRIPTION
It's discouraging to show failing CI at times where they are actually preferred over amend and rebase dances.

Tested at https://github.com/nextcloud/mail/pull/7793. The check was skipped for the draft PR but picked up when I clicked *Ready for review*