### PR TITLE
fix(workflows): Do not run workflows for direct pushes and merges

### DIFF
--- a/workflow-templates/lint-info-xml.yml
+++ b/workflow-templates/lint-info-xml.yml
@@ -7,7 +7,6 @@ name: Lint
 
 on:
   pull_request:
-  push:
     branches:
       - main
       - master

--- a/workflow-templates/lint-php.yml
+++ b/workflow-templates/lint-php.yml
@@ -5,13 +5,7 @@
 
 name: Lint
 
-on:
-  pull_request:
-  push:
-    branches:
-      - main
-      - master
-      - stable*
+on: pull_request
 
 permissions:
   contents: read

--- a/workflow-templates/lint-php.yml
+++ b/workflow-templates/lint-php.yml
@@ -5,7 +5,12 @@
 
 name: Lint
 
-on: pull_request
+on:
+  pull_request:
+    branches:
+      - main
+      - master
+      - stable*
 
 permissions:
   contents: read

--- a/workflow-templates/node.yml
+++ b/workflow-templates/node.yml
@@ -17,7 +17,6 @@ on:
       - '**.js'
       - '**.ts'
       - '**.vue'
-  push:
     branches:
       - main
       - master

--- a/workflow-templates/phpunit-mysql.yml
+++ b/workflow-templates/phpunit-mysql.yml
@@ -18,8 +18,6 @@ on:
       - '.php-cs-fixer.dist.php'
       - 'composer.json'
       - 'composer.lock'
-
-  push:
     branches:
       - main
       - master

--- a/workflow-templates/phpunit-oci.yml
+++ b/workflow-templates/phpunit-oci.yml
@@ -18,8 +18,6 @@ on:
       - '.php-cs-fixer.dist.php'
       - 'composer.json'
       - 'composer.lock'
-
-  push:
     branches:
       - main
       - master

--- a/workflow-templates/phpunit-pgsql.yml
+++ b/workflow-templates/phpunit-pgsql.yml
@@ -18,8 +18,6 @@ on:
       - '.php-cs-fixer.dist.php'
       - 'composer.json'
       - 'composer.lock'
-
-  push:
     branches:
       - main
       - master

--- a/workflow-templates/phpunit-sqlite.yml
+++ b/workflow-templates/phpunit-sqlite.yml
@@ -18,8 +18,6 @@ on:
       - '.php-cs-fixer.dist.php'
       - 'composer.json'
       - 'composer.lock'
-
-  push:
     branches:
       - main
       - master

--- a/workflow-templates/psalm-matrix.yml
+++ b/workflow-templates/psalm-matrix.yml
@@ -7,7 +7,6 @@ name: Static analysis
 
 on:
   pull_request:
-  push:
     branches:
       - master
       - main

--- a/workflow-templates/psalm.yml
+++ b/workflow-templates/psalm.yml
@@ -5,13 +5,7 @@
 
 name: Static analysis
 
-on:
-  pull_request:
-  push:
-    branches:
-      - master
-      - main
-      - stable*
+on: pull_request
 
 concurrency:
   group: psalm-${{ github.head_ref || github.run_id }}

--- a/workflow-templates/psalm.yml
+++ b/workflow-templates/psalm.yml
@@ -5,7 +5,12 @@
 
 name: Static analysis
 
-on: pull_request
+on:
+  pull_request:
+    branches:
+      - master
+      - main
+      - stable*
 
 concurrency:
   group: psalm-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
Checking pull requests should be sufficient. Some workflows already did that. Now it is consistent.

This has the potential of freeing a lot of CI time.