### PR TITLE
Upgrade `fallbackNode` and `fallbackNpm` to Nextcloud supported versions

### DIFF
--- a/workflow-templates/appstore-build-publish.yml
+++ b/workflow-templates/appstore-build-publish.yml
@@ -50,8 +50,8 @@ jobs:
         continue-on-error: true
         with:
           path: ${{ env.APP_NAME }}
-          fallbackNode: "^12"
-          fallbackNpm: "^6"
+          fallbackNode: "^16"
+          fallbackNpm: "^7"
 
       - name: Set up node ${{ steps.versions.outputs.nodeVersion }}
         # Skip if no package.json

--- a/workflow-templates/command-compile.yml
+++ b/workflow-templates/command-compile.yml
@@ -69,8 +69,8 @@ jobs:
         uses: skjnldsv/read-package-engines-version-actions@1bdcee71fa343c46b18dc6aceffb4cd1e35209c6 # v1.2
         id: package-engines-versions
         with:
-          fallbackNode: '^12'
-          fallbackNpm: '^6'
+          fallbackNode: '^16'
+          fallbackNpm: '^7'
 
       - name: Set up node ${{ steps.package-engines-versions.outputs.nodeVersion }}
         uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # v3

--- a/workflow-templates/lint-eslint.yml
+++ b/workflow-templates/lint-eslint.yml
@@ -44,8 +44,8 @@ jobs:
         uses: skjnldsv/read-package-engines-version-actions@1bdcee71fa343c46b18dc6aceffb4cd1e35209c6 # v1.2
         id: versions
         with:
-          fallbackNode: '^12'
-          fallbackNpm: '^6'
+          fallbackNode: '^16'
+          fallbackNpm: '^7'
 
       - name: Set up node ${{ steps.versions.outputs.nodeVersion }}
         uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # v3

--- a/workflow-templates/lint-stylelint.yml
+++ b/workflow-templates/lint-stylelint.yml
@@ -28,8 +28,8 @@ jobs:
         uses: skjnldsv/read-package-engines-version-actions@1bdcee71fa343c46b18dc6aceffb4cd1e35209c6 # v1.2
         id: versions
         with:
-          fallbackNode: '^12'
-          fallbackNpm: '^6'
+          fallbackNode: '^16'
+          fallbackNpm: '^7'
 
       - name: Set up node ${{ steps.versions.outputs.nodeVersion }}
         uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # v3

--- a/workflow-templates/node.yml
+++ b/workflow-templates/node.yml
@@ -43,8 +43,8 @@ jobs:
         uses: skjnldsv/read-package-engines-version-actions@1bdcee71fa343c46b18dc6aceffb4cd1e35209c6 # v1.2
         id: versions
         with:
-          fallbackNode: '^12'
-          fallbackNpm: '^6'
+          fallbackNode: '^16'
+          fallbackNpm: '^7'
 
       - name: Set up node ${{ steps.versions.outputs.nodeVersion }}
         uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # v3

--- a/workflow-templates/npm-publish.yml
+++ b/workflow-templates/npm-publish.yml
@@ -30,8 +30,8 @@ jobs:
         uses: skjnldsv/read-package-engines-version-actions@1bdcee71fa343c46b18dc6aceffb4cd1e35209c6 # v1.2
         id: versions
         with:
-          fallbackNode: '^12'
-          fallbackNpm: '^6'
+          fallbackNode: '^16'
+          fallbackNpm: '^7'
 
       - name: Set up node ${{ steps.versions.outputs.nodeVersion }}
         uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # v3


### PR DESCRIPTION
Upgrade fallbacks to the currently minimum supported (as per https://github.com/nextcloud/standards/issues/5 ) versions. 