### PR TITLE
fix(phpunit): Move the phpunit configs to composer

### DIFF
--- a/workflow-templates/phpunit-mysql.yml
+++ b/workflow-templates/phpunit-mysql.yml
@@ -32,11 +32,6 @@ concurrency:
   group: phpunit-mysql-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
-env:
-  # Location of the phpunit.xml and phpunit.integration.xml files
-  PHPUNIT_CONFIG: ./tests/phpunit.xml
-  PHPUNIT_INTEGRATION_CONFIG: ./tests/phpunit.integration.xml
-
 jobs:
   phpunit-mysql:
     runs-on: ubuntu-latest
@@ -82,7 +77,6 @@ jobs:
         uses: shivammathur/setup-php@1a18b2267f80291a81ca1d33e7c851fe09e7dfc4 # v2
         with:
           php-version: ${{ matrix.php-versions }}
-          tools: phpunit
           extensions: mbstring, iconv, fileinfo, intl, mysql, pdo_mysql
           coverage: none
         env:
@@ -94,7 +88,7 @@ jobs:
         with:
           files: apps/${{ env.APP_NAME }}/composer.json
 
-      - name: Set up PHPUnit
+      - name: Set up dependencies
         # Only run if phpunit config file exists
         if: steps.check_composer.outputs.files_exists == 'true'
         working-directory: apps/${{ env.APP_NAME }}
@@ -108,34 +102,36 @@ jobs:
           ./occ maintenance:install --verbose --database=mysql --database-name=nextcloud --database-host=127.0.0.1 --database-port=$DB_PORT --database-user=root --database-pass=rootpassword --admin-user admin --admin-pass password
           ./occ app:enable --force ${{ env.APP_NAME }}
 
-      - name: Check PHPUnit config file existence
+      - name: Check PHPUnit script is defined
         id: check_phpunit
-        uses: andstor/file-existence-action@20b4d2e596410855db8f9ca21e96fbe18e12930b # v2
-        with:
-          files: apps/${{ env.APP_NAME }}/${{ env.PHPUNIT_CONFIG }}
+        continue-on-error: true
+        working-directory: apps/${{ env.APP_NAME }}
+        run: |
+          composer run --list | grep "^  test:unit " | wc -l | grep 1
 
       - name: PHPUnit
         # Only run if phpunit config file exists
-        if: steps.check_phpunit.outputs.files_exists == 'true'
+        if: steps.check_phpunit.outcome == 'success'
         working-directory: apps/${{ env.APP_NAME }}
-        run: ./vendor/phpunit/phpunit/phpunit -c ${{ env.PHPUNIT_CONFIG }}
+        run: composer run test:unit
 
-      - name: Check PHPUnit integration config file existence
+      - name: Check PHPUnit integration script is defined
         id: check_integration
-        uses: andstor/file-existence-action@20b4d2e596410855db8f9ca21e96fbe18e12930b # v2
-        with:
-          files: apps/${{ env.APP_NAME }}/${{ env.PHPUNIT_INTEGRATION_CONFIG }}
+        continue-on-error: true
+        working-directory: apps/${{ env.APP_NAME }}
+        run: |
+          composer run --list | grep "^  test:integration " | wc -l | grep 1
 
       - name: Run Nextcloud
         # Only run if phpunit integration config file exists
-        if: steps.check_integration.outputs.files_exists == 'true'
+        if: steps.check_integration.outcome == 'success'
         run: php -S localhost:8080 &
 
       - name: PHPUnit integration
         # Only run if phpunit integration config file exists
-        if: steps.check_integration.outputs.files_exists == 'true'
+        if: steps.check_integration.outcome == 'success'
         working-directory: apps/${{ env.APP_NAME }}
-        run: ./vendor/phpunit/phpunit/phpunit -c ${{ env.PHPUNIT_INTEGRATION_CONFIG }}
+        run: composer run test:integration
 
   summary:
     permissions:

--- a/workflow-templates/phpunit-oci.yml
+++ b/workflow-templates/phpunit-oci.yml
@@ -32,11 +32,6 @@ concurrency:
   group: phpunit-oci-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
-env:
-  # Location of the phpunit.xml and phpunit.integration.xml files
-  PHPUNIT_CONFIG: ./tests/phpunit.xml
-  PHPUNIT_INTEGRATION_CONFIG: ./tests/phpunit.integration.xml
-
 jobs:
   phpunit-oci:
     runs-on: ubuntu-latest
@@ -75,7 +70,6 @@ jobs:
         with:
           php-version: ${{ matrix.php-versions }}
           extensions: mbstring, fileinfo, intl, sqlite, pdo_sqlite, oci8
-          tools: phpunit
           coverage: none
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -86,7 +80,7 @@ jobs:
         with:
           files: apps/${{ env.APP_NAME }}/composer.json
 
-      - name: Set up PHPUnit
+      - name: Set up dependencies
         # Only run if phpunit config file exists
         if: steps.check_composer.outputs.files_exists == 'true'
         working-directory: apps/${{ env.APP_NAME }}
@@ -100,34 +94,36 @@ jobs:
           ./occ maintenance:install --verbose --database=oci --database-name=XE --database-host=127.0.0.1 --database-port=$DB_PORT --database-user=autotest --database-pass=owncloud --admin-user admin --admin-pass admin
           ./occ app:enable --force ${{ env.APP_NAME }}
 
-      - name: Check PHPUnit config file existence
+      - name: Check PHPUnit script is defined
         id: check_phpunit
-        uses: andstor/file-existence-action@20b4d2e596410855db8f9ca21e96fbe18e12930b # v2
-        with:
-          files: apps/${{ env.APP_NAME }}/${{ env.PHPUNIT_CONFIG }}
+        continue-on-error: true
+        working-directory: apps/${{ env.APP_NAME }}
+        run: |
+          composer run --list | grep "^  test:unit " | wc -l | grep 1
 
       - name: PHPUnit
         # Only run if phpunit config file exists
-        if: steps.check_phpunit.outputs.files_exists == 'true'
+        if: steps.check_phpunit.outcome == 'success'
         working-directory: apps/${{ env.APP_NAME }}
-        run: ./vendor/phpunit/phpunit/phpunit -c ${{ env.PHPUNIT_CONFIG }}
+        run: composer run test:unit
 
-      - name: Check PHPUnit integration config file existence
+      - name: Check PHPUnit integration script is defined
         id: check_integration
-        uses: andstor/file-existence-action@20b4d2e596410855db8f9ca21e96fbe18e12930b # v2
-        with:
-          files: apps/${{ env.APP_NAME }}/${{ env.PHPUNIT_INTEGRATION_CONFIG }}
+        continue-on-error: true
+        working-directory: apps/${{ env.APP_NAME }}
+        run: |
+          composer run --list | grep "^  test:integration " | wc -l | grep 1
 
       - name: Run Nextcloud
         # Only run if phpunit integration config file exists
-        if: steps.check_integration.outputs.files_exists == 'true'
+        if: steps.check_integration.outcome == 'success'
         run: php -S localhost:8080 &
 
       - name: PHPUnit integration
         # Only run if phpunit integration config file exists
-        if: steps.check_integration.outputs.files_exists == 'true'
+        if: steps.check_integration.outcome == 'success'
         working-directory: apps/${{ env.APP_NAME }}
-        run: ./vendor/phpunit/phpunit/phpunit -c ${{ env.PHPUNIT_INTEGRATION_CONFIG }}
+        run: composer run test:integration
 
   summary:
     permissions:

--- a/workflow-templates/phpunit-pgsql.yml
+++ b/workflow-templates/phpunit-pgsql.yml
@@ -32,11 +32,6 @@ concurrency:
   group: phpunit-pgsql-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
-env:
-  # Location of the phpunit.xml and phpunit.integration.xml files
-  PHPUNIT_CONFIG: ./tests/phpunit.xml
-  PHPUNIT_INTEGRATION_CONFIG: ./tests/phpunit.integration.xml
-
 jobs:
   phpunit-pgsql:
     runs-on: ubuntu-latest
@@ -79,7 +74,6 @@ jobs:
         uses: shivammathur/setup-php@1a18b2267f80291a81ca1d33e7c851fe09e7dfc4 # v2
         with:
           php-version: ${{ matrix.php-versions }}
-          tools: phpunit
           extensions: mbstring, iconv, fileinfo, intl, pgsql, pdo_pgsql
           coverage: none
         env:
@@ -91,7 +85,7 @@ jobs:
         with:
           files: apps/${{ env.APP_NAME }}/composer.json
 
-      - name: Set up PHPUnit
+      - name: Set up dependencies
         # Only run if phpunit config file exists
         if: steps.check_composer.outputs.files_exists == 'true'
         working-directory: apps/${{ env.APP_NAME }}
@@ -105,34 +99,36 @@ jobs:
           ./occ maintenance:install --verbose --database=pgsql --database-name=nextcloud --database-host=127.0.0.1 --database-port=$DB_PORT --database-user=root --database-pass=rootpassword --admin-user admin --admin-pass password
           ./occ app:enable --force ${{ env.APP_NAME }}
 
-      - name: Check PHPUnit config file existence
+      - name: Check PHPUnit script is defined
         id: check_phpunit
-        uses: andstor/file-existence-action@20b4d2e596410855db8f9ca21e96fbe18e12930b # v2
-        with:
-          files: apps/${{ env.APP_NAME }}/${{ env.PHPUNIT_CONFIG }}
+        continue-on-error: true
+        working-directory: apps/${{ env.APP_NAME }}
+        run: |
+          composer run --list | grep "^  test:unit " | wc -l | grep 1
 
       - name: PHPUnit
         # Only run if phpunit config file exists
-        if: steps.check_phpunit.outputs.files_exists == 'true'
+        if: steps.check_phpunit.outcome == 'success'
         working-directory: apps/${{ env.APP_NAME }}
-        run: ./vendor/phpunit/phpunit/phpunit -c ${{ env.PHPUNIT_CONFIG }}
+        run: composer run test:unit
 
-      - name: Check PHPUnit integration config file existence
+      - name: Check PHPUnit integration script is defined
         id: check_integration
-        uses: andstor/file-existence-action@20b4d2e596410855db8f9ca21e96fbe18e12930b # v2
-        with:
-          files: apps/${{ env.APP_NAME }}/${{ env.PHPUNIT_INTEGRATION_CONFIG }}
+        continue-on-error: true
+        working-directory: apps/${{ env.APP_NAME }}
+        run: |
+          composer run --list | grep "^  test:integration " | wc -l | grep 1
 
       - name: Run Nextcloud
         # Only run if phpunit integration config file exists
-        if: steps.check_integration.outputs.files_exists == 'true'
+        if: steps.check_integration.outcome == 'success'
         run: php -S localhost:8080 &
 
       - name: PHPUnit integration
         # Only run if phpunit integration config file exists
-        if: steps.check_integration.outputs.files_exists == 'true'
+        if: steps.check_integration.outcome == 'success'
         working-directory: apps/${{ env.APP_NAME }}
-        run: ./vendor/phpunit/phpunit/phpunit -c ${{ env.PHPUNIT_INTEGRATION_CONFIG }}
+        run: composer run test:integration
 
   summary:
     permissions:

--- a/workflow-templates/phpunit-sqlite.yml
+++ b/workflow-templates/phpunit-sqlite.yml
@@ -32,11 +32,6 @@ concurrency:
   group: phpunit-sqlite-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
-env:
-  # Location of the phpunit.xml and phpunit.integration.xml files
-  PHPUNIT_CONFIG: ./tests/phpunit.xml
-  PHPUNIT_INTEGRATION_CONFIG: ./tests/phpunit.integration.xml
-
 jobs:
   phpunit-sqlite:
     runs-on: ubuntu-latest
@@ -68,7 +63,6 @@ jobs:
         uses: shivammathur/setup-php@1a18b2267f80291a81ca1d33e7c851fe09e7dfc4 # v2
         with:
           php-version: ${{ matrix.php-versions }}
-          tools: phpunit
           extensions: mbstring, iconv, fileinfo, intl, sqlite, pdo_sqlite
           coverage: none
         env:
@@ -80,7 +74,7 @@ jobs:
         with:
           files: apps/${{ env.APP_NAME }}/composer.json
 
-      - name: Set up PHPUnit
+      - name: Set up dependencies
         # Only run if phpunit config file exists
         if: steps.check_composer.outputs.files_exists == 'true'
         working-directory: apps/${{ env.APP_NAME }}
@@ -94,34 +88,36 @@ jobs:
           ./occ maintenance:install --verbose --database=sqlite --database-name=nextcloud --database-host=127.0.0.1 --database-port=$DB_PORT --database-user=root --database-pass=rootpassword --admin-user admin --admin-pass password
           ./occ app:enable --force ${{ env.APP_NAME }}
 
-      - name: Check PHPUnit config file existence
+      - name: Check PHPUnit script is defined
         id: check_phpunit
-        uses: andstor/file-existence-action@20b4d2e596410855db8f9ca21e96fbe18e12930b # v2
-        with:
-          files: apps/${{ env.APP_NAME }}/${{ env.PHPUNIT_CONFIG }}
+        continue-on-error: true
+        working-directory: apps/${{ env.APP_NAME }}
+        run: |
+          composer run --list | grep "^  test:unit " | wc -l | grep 1
 
       - name: PHPUnit
         # Only run if phpunit config file exists
-        if: steps.check_phpunit.outputs.files_exists == 'true'
+        if: steps.check_phpunit.outcome == 'success'
         working-directory: apps/${{ env.APP_NAME }}
-        run: ./vendor/phpunit/phpunit/phpunit -c ${{ env.PHPUNIT_CONFIG }}
+        run: composer run test:unit
 
-      - name: Check PHPUnit integration config file existence
+      - name: Check PHPUnit integration script is defined
         id: check_integration
-        uses: andstor/file-existence-action@20b4d2e596410855db8f9ca21e96fbe18e12930b # v2
-        with:
-          files: apps/${{ env.APP_NAME }}/${{ env.PHPUNIT_INTEGRATION_CONFIG }}
+        continue-on-error: true
+        working-directory: apps/${{ env.APP_NAME }}
+        run: |
+          composer run --list | grep "^  test:integration " | wc -l | grep 1
 
       - name: Run Nextcloud
         # Only run if phpunit integration config file exists
-        if: steps.check_integration.outputs.files_exists == 'true'
+        if: steps.check_integration.outcome == 'success'
         run: php -S localhost:8080 &
 
       - name: PHPUnit integration
         # Only run if phpunit integration config file exists
-        if: steps.check_integration.outputs.files_exists == 'true'
+        if: steps.check_integration.outcome == 'success'
         working-directory: apps/${{ env.APP_NAME }}
-        run: ./vendor/phpunit/phpunit/phpunit -c ${{ env.PHPUNIT_INTEGRATION_CONFIG }}
+        run: composer run test:integration
 
   summary:
     permissions:


### PR DESCRIPTION
- Removes phpunit as a tool as we execute vendor/bin/phpunit anyway
- Improves cross copying the files when
  + phpunit.xml is in a non-default location or name (e.g. spreed, notifications, mail, …)
  + phpunit binary is in a non-default location e.g. vendor-bin/ (e.g. external, spreed, mail, ...)

Signed-off-by: Joas Schilling <coding@schilljs.com>