### PR TITLE
feat(phpunit): Fail the action when unit and integration tests are sk…

### DIFF
--- a/workflow-templates/phpunit-mysql.yml
+++ b/workflow-templates/phpunit-mysql.yml
@@ -133,6 +133,13 @@ jobs:
         working-directory: apps/${{ env.APP_NAME }}
         run: composer run test:integration
 
+      - name: Skipped
+        # Fail the action when neither unit nor integration tests ran
+        if: steps.check_phpunit.outcome == 'failure' && steps.check_integration.outcome == 'failure'
+        run: |
+          echo 'Neither PHPUnit nor PHPUnit integration tests are specified in composer.json scripts'
+          exit 1
+
   summary:
     permissions:
       contents: none

--- a/workflow-templates/phpunit-oci.yml
+++ b/workflow-templates/phpunit-oci.yml
@@ -125,6 +125,13 @@ jobs:
         working-directory: apps/${{ env.APP_NAME }}
         run: composer run test:integration
 
+      - name: Skipped
+        # Fail the action when neither unit nor integration tests ran
+        if: steps.check_phpunit.outcome == 'failure' && steps.check_integration.outcome == 'failure'
+        run: |
+          echo 'Neither PHPUnit nor PHPUnit integration tests are specified in composer.json scripts'
+          exit 1
+
   summary:
     permissions:
       contents: none

--- a/workflow-templates/phpunit-pgsql.yml
+++ b/workflow-templates/phpunit-pgsql.yml
@@ -130,6 +130,13 @@ jobs:
         working-directory: apps/${{ env.APP_NAME }}
         run: composer run test:integration
 
+      - name: Skipped
+        # Fail the action when neither unit nor integration tests ran
+        if: steps.check_phpunit.outcome == 'failure' && steps.check_integration.outcome == 'failure'
+        run: |
+          echo 'Neither PHPUnit nor PHPUnit integration tests are specified in composer.json scripts'
+          exit 1
+
   summary:
     permissions:
       contents: none

--- a/workflow-templates/phpunit-sqlite.yml
+++ b/workflow-templates/phpunit-sqlite.yml
@@ -119,6 +119,13 @@ jobs:
         working-directory: apps/${{ env.APP_NAME }}
         run: composer run test:integration
 
+      - name: Skipped
+        # Fail the action when neither unit nor integration tests ran
+        if: steps.check_phpunit.outcome == 'failure' && steps.check_integration.outcome == 'failure'
+        run: |
+          echo 'Neither PHPUnit nor PHPUnit integration tests are specified in composer.json scripts'
+          exit 1
+
   summary:
     permissions:
       contents: none


### PR DESCRIPTION
…ipped

This should help app developers to detect that they set up unit tests but are not executing anything anymore due to the composer script requirement
Ref #115 