### PR TITLE
fix(fixup): Add back `synchronize` event type

### DIFF
--- a/workflow-templates/fixup.yml
+++ b/workflow-templates/fixup.yml
@@ -7,7 +7,7 @@ name: Pull request checks
 
 on:
   pull_request:
-    types: [opened, ready_for_review, reopened]
+    types: [opened, ready_for_review, reopened, synchronize]
 
 permissions:
   contents: read


### PR DESCRIPTION
By default, a workflow only runs when a pull_request event's activity type is opened, synchronize, or reopened. https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request


Signed-off-by: John Molakvoæ <skjnldsv@users.noreply.github.com>