### PR TITLE
fix(update-nextcloud-ocp): Fix resetting other dependencies

### DIFF
--- a/workflow-templates/update-nextcloud-ocp-matrix.yml
+++ b/workflow-templates/update-nextcloud-ocp-matrix.yml
@@ -44,12 +44,22 @@ jobs:
         run: composer require --dev nextcloud/ocp:dev-${{ matrix.target }}
         continue-on-error: true
 
-      - name: Reset checkout dirs
+      - name: Reset checkout 3rdparty
         run: |
           git clean -f 3rdparty
+          git checkout 3rdparty
+        continue-on-error: true
+
+      - name: Reset checkout vendor
+        run: |
           git clean -f vendor
+          git checkout vendor
+        continue-on-error: true
+
+      - name: Reset checkout vendor-bin
+        run: |
           git clean -f vendor-bin
-          git checkout 3rdparty vendor vendor-bin
+          git checkout vendor-bin
         continue-on-error: true
 
       - name: Create Pull Request

--- a/workflow-templates/update-nextcloud-ocp-matrix.yml
+++ b/workflow-templates/update-nextcloud-ocp-matrix.yml
@@ -42,7 +42,6 @@ jobs:
 
       - name: Composer update nextcloud/ocp
         run: composer require --dev nextcloud/ocp:dev-${{ matrix.target }}
-        continue-on-error: true
 
       - name: Reset checkout 3rdparty
         run: |

--- a/workflow-templates/update-nextcloud-ocp.yml
+++ b/workflow-templates/update-nextcloud-ocp.yml
@@ -41,7 +41,6 @@ jobs:
 
       - name: Composer update nextcloud/ocp
         run: composer require --dev nextcloud/ocp:dev-${{ matrix.branches }}
-        continue-on-error: true
 
       - name: Reset checkout 3rdparty
         run: |

--- a/workflow-templates/update-nextcloud-ocp.yml
+++ b/workflow-templates/update-nextcloud-ocp.yml
@@ -43,12 +43,22 @@ jobs:
         run: composer require --dev nextcloud/ocp:dev-${{ matrix.branches }}
         continue-on-error: true
 
-      - name: Reset checkout dirs
+      - name: Reset checkout 3rdparty
         run: |
           git clean -f 3rdparty
+          git checkout 3rdparty
+        continue-on-error: true
+
+      - name: Reset checkout vendor
+        run: |
           git clean -f vendor
+          git checkout vendor
+        continue-on-error: true
+
+      - name: Reset checkout vendor-bin
+        run: |
           git clean -f vendor-bin
-          git checkout 3rdparty vendor vendor-bin
+          git checkout vendor-bin
         continue-on-error: true
 
       - name: Create Pull Request


### PR DESCRIPTION
1. Drive-by fix: composer require of the OCP package is not continuing on error anymore.
2. Finally figured out why the OCP package always updates phpunit, psalm and more:
https://github.com/nextcloud/spreed/actions/runs/4586488511/jobs/8099376551#step:6:13

The problem is `git checkout` aborts all things when one path is not existing.

```
$ composer require --dev nextcloud/ocp:dev-stable26

…

git status && git clean -f 3rdparty vendor vendor-bin && git status && git checkout 3rdparty vendor vendor-bin && git status
On branch stable26
You are currently bisecting, started from branch 'stable26'.
  (use "git bisect reset" to get back to the original branch)

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   composer.lock
	modified:   vendor-bin/csfixer/composer.lock
	modified:   vendor-bin/mozart/composer.lock
	modified:   vendor-bin/phpunit/composer.lock
	modified:   vendor-bin/psalm/composer.lock

no changes added to commit (use "git add" and/or "git commit -a")
On branch stable26
You are currently bisecting, started from branch 'stable26'.
  (use "git bisect reset" to get back to the original branch)

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   composer.lock
	modified:   vendor-bin/csfixer/composer.lock
	modified:   vendor-bin/mozart/composer.lock
	modified:   vendor-bin/phpunit/composer.lock
	modified:   vendor-bin/psalm/composer.lock

no changes added to commit (use "git add" and/or "git commit -a")
error: pathspec '3rdparty' did not match any file(s) known to git
error: pathspec 'vendor' did not match any file(s) known to git
```

Splitting it to multiple things is working as expected:
```
git status && git clean -f 3rdparty vendor vendor-bin && git status && (git checkout 3rdparty || git checkout vendor || git checkout vendor-bin) && git status
$ git status && git clean -f 3rdparty vendor vendor-bin && git status && (git checkout 3rdparty || git checkout vendor || git checkout vendor-bin) && git status
On branch stable26
You are currently bisecting, started from branch 'stable26'.
  (use "git bisect reset" to get back to the original branch)

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   composer.lock
	modified:   vendor-bin/csfixer/composer.lock
	modified:   vendor-bin/mozart/composer.lock
	modified:   vendor-bin/phpunit/composer.lock
	modified:   vendor-bin/psalm/composer.lock

no changes added to commit (use "git add" and/or "git commit -a")
On branch stable26
You are currently bisecting, started from branch 'stable26'.
  (use "git bisect reset" to get back to the original branch)

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   composer.lock
	modified:   vendor-bin/csfixer/composer.lock
	modified:   vendor-bin/mozart/composer.lock
	modified:   vendor-bin/phpunit/composer.lock
	modified:   vendor-bin/psalm/composer.lock

no changes added to commit (use "git add" and/or "git commit -a")
error: pathspec '3rdparty' did not match any file(s) known to git
error: pathspec 'vendor' did not match any file(s) known to git
Updated 4 paths from the index
On branch stable26
You are currently bisecting, started from branch 'stable26'.
  (use "git bisect reset" to get back to the original branch)

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   composer.lock

no changes added to commit (use "git add" and/or "git commit -a")
```

So we are doing it one-by-one now and the result is the expected one (only root composer.lock modified).