### PR TITLE
change npm-audit-fix into a matrix run

### DIFF
--- a/workflow-templates/npm-audit-fix.yml
+++ b/workflow-templates/npm-audit-fix.yml
@@ -47,6 +47,7 @@ jobs:
           npm run build --if-present
 
       - name: Create Pull Request
+        if: always()
         uses: peter-evans/create-pull-request@18f7dc018cc2cd597073088f7c7591b9d1c02672 # v3
         with:
           token: ${{ secrets.COMMAND_BOT_PAT }}

--- a/workflow-templates/npm-audit-fix.yml
+++ b/workflow-templates/npm-audit-fix.yml
@@ -12,10 +12,18 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-    name: node
+    strategy:
+      fail-fast: false
+      matrix:
+        branches: ["main", "master", "stable26", "stable25", "stable24"]
+  
+    name: npm-audit-fix-${{ matrix.branches }}
+
     steps:
       - name: Checkout
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3
+        with:
+          ref: ${{ matrix.branches }}
 
       - name: Read package.json node and npm engines version
         uses: skjnldsv/read-package-engines-version-actions@1bdcee71fa343c46b18dc6aceffb4cd1e35209c6 # v1.2

--- a/workflow-templates/npm-audit-fix.yml
+++ b/workflow-templates/npm-audit-fix.yml
@@ -8,7 +8,8 @@ name: npm audit fix and compile
 on:
   workflow_dispatch:
   schedule:
-    - cron: '5 2 * * 0'
+    # At 2:30 on Sundays
+    - cron: '30 2 * * 0'
 
 jobs:
   build:

--- a/workflow-templates/npm-audit-fix.yml
+++ b/workflow-templates/npm-audit-fix.yml
@@ -7,6 +7,8 @@ name: npm audit fix and compile
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: '5 2 * * 0'
 
 jobs:
   build:


### PR DESCRIPTION
Advantage: we only need to maintain the workflow in master and can trigger updates with one click.

Example run in https://github.com/nextcloud/viewer/actions/runs/4830795292