### PR TITLE
allow dependency up downgrade for ocp peer dependencies

### DIFF
--- a/workflow-templates/psalm-matrix.yml
+++ b/workflow-templates/psalm-matrix.yml
@@ -44,7 +44,7 @@ jobs:
         run: composer i
 
       - name: Install dependencies
-        run: composer require --dev nextcloud/ocp:${{ matrix.ocp-version }} --ignore-platform-reqs
+        run: composer require --dev nextcloud/ocp:${{ matrix.ocp-version }} --ignore-platform-reqs --with-dependencies
 
       - name: Run coding standards check
         run: composer run psalm


### PR DESCRIPTION
Example with patch: https://github.com/nextcloud/mail/actions/runs/5083890915/jobs/9135458154?pr=8496

![image](https://github.com/nextcloud/.github/assets/3902676/6fc921a0-481e-4a88-8db4-5a20982d6bba)

Example without patch: https://github.com/nextcloud/social/actions/runs/5082148997/jobs/9131503707

![image](https://github.com/nextcloud/.github/assets/3902676/9ff4f45a-1cbd-425a-9013-ed9b232a3a7f)
