### PR TITLE
feat: add classmap-authoritative to appstore-build-publish

### DIFF
--- a/workflow-templates/appstore-build-publish.yml
+++ b/workflow-templates/appstore-build-publish.yml
@@ -83,7 +83,7 @@ jobs:
         if: steps.check_composer.outputs.files_exists == 'true'
         run: |
           cd ${{ env.APP_NAME }}
-          composer install --no-dev
+          composer install --no-dev --classmap-authoritative
 
       - name: Build ${{ env.APP_NAME }}
         # Skip if no package.json


### PR DESCRIPTION
https://github.com/nextcloud/spreed/pull/9629#discussion_r1206605890
https://getcomposer.org/doc/articles/autoloader-optimization.md

# Optimization Level 2/A: Authoritative class maps
## How to run it?
There are a few options to enable this:

- Set "classmap-authoritative": true inside the config key of composer.json
- Call install or update with -a / --classmap-authoritative
- Call dump-autoload with -a / --classmap-authoritative

## What does it do?
Enabling this automatically enables Level 1 class map optimizations.

This option says that if something is not found in the classmap, then it does not exist and the autoloader should not attempt to look on the filesystem according to PSR-4 rules.

## Trade-offs
This option makes the autoloader always return very quickly. On the flipside it also means that in case a class is generated at runtime for some reason, it will not be allowed to be autoloaded. If your project or any of your dependencies does that then you might experience "class not found" issues in production. Enable this with care.

Note: This cannot be combined with Level 2/B optimizations. You have to choose one as they address the same issue in different ways.