### PR TITLE
fix(documentation): allow to test build if we're not pushing new docs

### DIFF
--- a/workflow-templates/documentation.yml
+++ b/workflow-templates/documentation.yml
@@ -12,6 +12,8 @@ jobs:
     name: Build and deploy
     steps:
       - name: Check actor permission level
+        # Only allow admin to deploy on release
+        if: github.event.release
         uses: skjnldsv/check-actor-permission@e591dbfe838300c007028e1219ca82cc26e8d7c5 # v2
         with:
           require: admin


### PR DESCRIPTION
No need to check for author permission if we're just building the docs without publishing them