### PR TITLE
feat: cache git repository for faster checkout

### DIFF
--- a/workflow-templates/command-compile.yml
+++ b/workflow-templates/command-compile.yml
@@ -53,6 +53,12 @@ jobs:
     needs: init
 
     steps:
+      - name: Restore cached git repository
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        with:
+          path: .git
+          key: git-repo
+
       - name: Checkout ${{ needs.init.outputs.head_ref }}
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
         with:


### PR DESCRIPTION
On server, this reduce the workflow time by half! :speedboat: :rocket: 
Do you see any other location this might be useful?

- No cache: https://github.com/skjnldsv/server/actions/runs/5364983983/jobs/9733513243
  ![image](https://github.com/nextcloud/.github/assets/14975046/04027acf-f75f-428a-a21e-b816402c0673)
- Cache: https://github.com/skjnldsv/server/actions/runs/5365018048/jobs/9733568097
  ![image](https://github.com/nextcloud/.github/assets/14975046/fa6bc847-1e2b-4dee-992f-593a1dc928dd)
