### PR TITLE
feat(npm-publish): Also publish packages on github package registry

### DIFF
--- a/workflow-templates/npm-publish.yml
+++ b/workflow-templates/npm-publish.yml
@@ -52,3 +52,13 @@ jobs:
           npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Setup Github Package Registry
+        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3
+        with:
+          registry-url: 'https://npm.pkg.github.com'
+
+      - name: Publish package on GPR
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Some packages like the `nextcloud-axios` package are already published on NPM **and** on GPR.
Pro: Less monopolization + redundancy