### PR TITLE
fix: cypress template

### DIFF
--- a/workflow-templates/cypress.yml
+++ b/workflow-templates/cypress.yml
@@ -38,8 +38,8 @@ jobs:
         uses: skjnldsv/read-package-engines-version-actions@0ce2ed60f6df073a62a77c0a4958dd0fc68e32e7 # v2.1
         id: versions
         with:
-          fallbackNode: "^14"
-          fallbackNpm: "^7"
+          fallbackNode: "^20"
+          fallbackNpm: "^9"
 
       - name: Set up node ${{ steps.versions.outputs.nodeVersion }}
         uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0

--- a/workflow-templates/cypress.yml
+++ b/workflow-templates/cypress.yml
@@ -16,6 +16,9 @@ env:
 jobs:
   init:
     runs-on: ubuntu-latest
+    outputs:
+      nodeVersion: ${{ steps.versions.outputs.nodeVersion }}
+      npmVersion: ${{ steps.versions.outputs.npmVersion }}
 
     steps:
       - name: Checkout app
@@ -41,7 +44,6 @@ jobs:
       - name: Set up node ${{ steps.versions.outputs.nodeVersion }}
         uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
         with:
-          cache: "npm"
           node-version: ${{ steps.versions.outputs.nodeVersion }}
 
       - name: Set up npm ${{ steps.versions.outputs.npmVersion }}
@@ -82,7 +84,6 @@ jobs:
       - name: Set up node ${{ needs.init.outputs.nodeVersion }}
         uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
         with:
-          cache: "npm"
           node-version: ${{ needs.init.outputs.nodeVersion }}
 
       - name: Set up npm ${{ needs.init.outputs.npmVersion }}


### PR DESCRIPTION
- Disable npm cache because of https://github.com/actions/cache/issues/720 (we gain 30 seconds per runner)
- Fix node/npm engines output
- Fix fallbackNode and fallbackNpm versions