### PR TITLE
Ignore failed checkout in update-nextcloud-ocp.yml

### DIFF
--- a/workflow-templates/update-nextcloud-ocp.yml
+++ b/workflow-templates/update-nextcloud-ocp.yml
@@ -22,12 +22,15 @@ jobs:
     name: update-nextcloud-ocp-${{ matrix.branches }}
 
     steps:
-      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - id: checkout
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
         with:
           ref: ${{ matrix.branches }}
           submodules: true
+        continue-on-error: true
 
       - name: Set up php8.1
+        if: steps.checkout.outcome == 'success'
         uses: shivammathur/setup-php@4bd44f22a98a19e0950cbad5f31095157cc9621b # v2
         with:
           php-version: 8.1
@@ -38,22 +41,24 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Read codeowners
+        if: steps.checkout.outcome == 'success'
         id: codeowners
         run: |
           grep '/appinfo/info.xml' .github/CODEOWNERS | awk '{ print "codeowners="$2 }' >> $GITHUB_OUTPUT
         continue-on-error: true
 
       - name: Composer install
+        if: steps.checkout.outcome == 'success'
         run: composer install
 
       - name: Composer update nextcloud/ocp
         id: update_branch
-        if: matrix.branches != 'main'
+        if: ${{ steps.checkout.outcome == 'success' && matrix.branches != 'main' }}
         run: composer require --dev nextcloud/ocp:dev-${{ matrix.branches }}
 
       - name: Raise on issue on failure
         uses: dacbd/create-issue-action@ba4d1c45cccf9c483f2720cefb40e437f0ee6f7d # v1.2.1
-        if: ${{ failure() && steps.update_branch.conclusion == 'failure' }}
+        if: ${{ steps.checkout.outcome == 'success' && failure() && steps.update_branch.conclusion == 'failure' }}
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           title: Failed to update nextcloud/ocp package on branch ${{ matrix.branches }}
@@ -61,36 +66,40 @@ jobs:
 
       - name: Composer update nextcloud/ocp
         id: update_main
-        if: matrix.branches == 'main'
+        if: ${{ steps.checkout.outcome == 'success' && matrix.branches == 'main' }}
         run: composer require --dev nextcloud/ocp:dev-master
 
       - name: Raise on issue on failure
         uses: dacbd/create-issue-action@ba4d1c45cccf9c483f2720cefb40e437f0ee6f7d # v1.2.1
-        if: ${{ failure() && steps.update_main.conclusion == 'failure' }}
+        if: ${{ steps.checkout.outcome == 'success' && failure() && steps.update_main.conclusion == 'failure' }}
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           title: Failed to update nextcloud/ocp package on branch ${{ matrix.branches }}
           body: Please check the output of the GitHub action and manually resolve the issues<br>${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}<br>${{ steps.codeowners.outputs.codeowners }}
 
       - name: Reset checkout 3rdparty
+        if: steps.checkout.outcome == 'success'
         run: |
           git clean -f 3rdparty
           git checkout 3rdparty
         continue-on-error: true
 
       - name: Reset checkout vendor
+        if: steps.checkout.outcome == 'success'
         run: |
           git clean -f vendor
           git checkout vendor
         continue-on-error: true
 
       - name: Reset checkout vendor-bin
+        if: steps.checkout.outcome == 'success'
         run: |
           git clean -f vendor-bin
           git checkout vendor-bin
         continue-on-error: true
 
       - name: Create Pull Request
+        if: steps.checkout.outcome == 'success'
         uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38 # v3
         with:
           token: ${{ secrets.COMMAND_BOT_PAT }}


### PR DESCRIPTION
This is to avoid having a failed job for main when using master or the other way around.