### PR TITLE
fix(update-nextcloud-ocp): Ping all maintainers

### DIFF
--- a/workflow-templates/update-nextcloud-ocp.yml
+++ b/workflow-templates/update-nextcloud-ocp.yml
@@ -44,7 +44,7 @@ jobs:
         if: steps.checkout.outcome == 'success'
         id: codeowners
         run: |
-          grep '/appinfo/info.xml' .github/CODEOWNERS | awk '{ print "codeowners="$2 }' >> $GITHUB_OUTPUT
+          grep '/appinfo/info.xml' .github/CODEOWNERS | cut -f 2- -d ' ' | xargs | awk '{ print "codeowners="$0 }' >> $GITHUB_OUTPUT
         continue-on-error: true
 
       - name: Composer install


### PR DESCRIPTION
Noticed in https://github.com/nextcloud/notifications/issues/1629

## Before
```
notifications$ grep '/appinfo/info.xml' .github/CODEOWNERS | awk '{ print "codeowners="$2 }'
codeowners=@Antreesy
```

## After
```
notifications$ grep '/appinfo/info.xml' .github/CODEOWNERS | cut -f 2- -d ' ' | xargs | awk '{ print "codeowners="$0 }'
codeowners=@Antreesy @nickvergessen
```