### PR TITLE
perf(npm): only install cypress when needed

### DIFF
--- a/workflow-templates/appstore-build-publish.yml
+++ b/workflow-templates/appstore-build-publish.yml
@@ -88,6 +88,8 @@ jobs:
       - name: Build ${{ env.APP_NAME }}
         # Skip if no package.json
         if: ${{ steps.versions.outputs.nodeVersion }}
+        env:
+          CYPRESS_INSTALL_BINARY: 0
         run: |
           cd ${{ env.APP_NAME }}
           npm ci

--- a/workflow-templates/command-compile.yml
+++ b/workflow-templates/command-compile.yml
@@ -88,6 +88,8 @@ jobs:
         run: npm i -g npm@"${{ steps.package-engines-versions.outputs.npmVersion }}"
 
       - name: Install dependencies & build
+        env:
+          CYPRESS_INSTALL_BINARY: 0
         run: |
           npm ci
           npm run build --if-present

--- a/workflow-templates/documentation.yml
+++ b/workflow-templates/documentation.yml
@@ -37,6 +37,8 @@ jobs:
         run: npm i -g npm@"${{ steps.versions.outputs.npmVersion }}"
 
       - name: Install dependencies & build
+        env:
+          CYPRESS_INSTALL_BINARY: 0
         run: |
           npm ci
           npm run build --if-present

--- a/workflow-templates/lint-eslint.yml
+++ b/workflow-templates/lint-eslint.yml
@@ -56,6 +56,8 @@ jobs:
         run: npm i -g npm@"${{ steps.versions.outputs.npmVersion }}"
 
       - name: Install dependencies
+        env:
+          CYPRESS_INSTALL_BINARY: 0
         run: npm ci
 
       - name: Lint

--- a/workflow-templates/lint-stylelint.yml
+++ b/workflow-templates/lint-stylelint.yml
@@ -40,6 +40,8 @@ jobs:
         run: npm i -g npm@"${{ steps.versions.outputs.npmVersion }}"
 
       - name: Install dependencies
+        env:
+          CYPRESS_INSTALL_BINARY: 0
         run: npm ci
 
       - name: Lint

--- a/workflow-templates/node-test.yml
+++ b/workflow-templates/node-test.yml
@@ -39,6 +39,8 @@ jobs:
         run: npm i -g npm@"${{ steps.versions.outputs.npmVersion }}"
 
       - name: Install dependencies & build
+        env:
+          CYPRESS_INSTALL_BINARY: 0
         run: |
           npm ci
           npm run build --if-present

--- a/workflow-templates/node.yml
+++ b/workflow-templates/node.yml
@@ -55,6 +55,8 @@ jobs:
         run: npm i -g npm@"${{ steps.versions.outputs.npmVersion }}"
 
       - name: Install dependencies & build
+        env:
+          CYPRESS_INSTALL_BINARY: 0
         run: |
           npm ci
           npm run build --if-present

--- a/workflow-templates/npm-audit-fix.yml
+++ b/workflow-templates/npm-audit-fix.yml
@@ -49,6 +49,8 @@ jobs:
 
       - name: Run npm ci and npm run build
         if: always()
+        env:
+          CYPRESS_INSTALL_BINARY: 0
         run: |
           npm ci
           npm run build --if-present

--- a/workflow-templates/npm-publish.yml
+++ b/workflow-templates/npm-publish.yml
@@ -43,6 +43,8 @@ jobs:
         run: npm i -g npm@"${{ steps.versions.outputs.npmVersion }}"
 
       - name: Install dependencies & build
+        env:
+          CYPRESS_INSTALL_BINARY: 0
         run: |
           npm ci
           npm run build --if-present


### PR DESCRIPTION
We run `npm ci` in a number of places
and usually we do not need cypress to be installed.

In text a [sample run](https://github.com/nextcloud/text/actions/runs/6025685889/job/16346936805?pr=4747#step:6:51) of `npm ci` without cypress took 24 sec. instead of [43 sec](https://github.com/nextcloud/text/actions/runs/6025539366/job/16346460340#step:6:49).

This also prevents run failures due to network issues connecting to cypress.

Documentation for the environment variable used:
https://docs.cypress.io/guides/references/advanced-installation#Skipping-installation