### PR TITLE
ci: skip puppeteer chrome download

### DIFF
--- a/workflow-templates/command-compile.yml
+++ b/workflow-templates/command-compile.yml
@@ -90,6 +90,7 @@ jobs:
       - name: Install dependencies & build
         env:
           CYPRESS_INSTALL_BINARY: 0
+          PUPPETEER_SKIP_DOWNLOAD: true
         run: |
           npm ci
           npm run build --if-present

--- a/workflow-templates/cypress.yml
+++ b/workflow-templates/cypress.yml
@@ -25,6 +25,9 @@ jobs:
       nodeVersion: ${{ steps.versions.outputs.nodeVersion }}
       npmVersion: ${{ steps.versions.outputs.npmVersion }}
 
+    env:
+      PUPPETEER_SKIP_DOWNLOAD: true
+
     steps:
       - name: Checkout app
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0

--- a/workflow-templates/lint-eslint.yml
+++ b/workflow-templates/lint-eslint.yml
@@ -58,6 +58,7 @@ jobs:
       - name: Install dependencies
         env:
           CYPRESS_INSTALL_BINARY: 0
+          PUPPETEER_SKIP_DOWNLOAD: true
         run: npm ci
 
       - name: Lint

--- a/workflow-templates/node.yml
+++ b/workflow-templates/node.yml
@@ -57,6 +57,7 @@ jobs:
       - name: Install dependencies & build
         env:
           CYPRESS_INSTALL_BINARY: 0
+          PUPPETEER_SKIP_DOWNLOAD: true
         run: |
           npm ci
           npm run build --if-present


### PR DESCRIPTION
Upstreaming https://github.com/nextcloud/server/pull/40733

I'm uncertain if skip puppeteer download is a reasonable default for everyone. 

Beside server only text has puppeteer as dependency.