### PR TITLE
Update SECURITY.md - Bring it up to par with the one in `server`

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -32,7 +32,11 @@ Your report should include:
 You should receive an initial acknowledgement within 24 hours in most cases.
 
 A member of the security team will confirm the vulnerability, determine its impact, follow-up with any questions, 
-and coordinate the fix and publication.
+and coordinate the fix and publication. 
+
+If the vulnerability involves an app that is not formally maintained by Nextcloud (i.e. hosted by the 
+Nextcloud project but community maintained), the security team will contact the current maintainer 
+and help make sure the issue gets fixed.
 
 The fix will be applied to all applicable and still supported stable branches, tested, and packaged in the next security release.
 The vulnerability will be publicly announced after the release. Finally, your name will be added

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,14 +1,14 @@
 # Security Policy
 
-[Security](https://nextcloud.com/security/) is very important to us. 
+[Security](https://nextcloud.com/security/) is very important to us.
 
-If you believe you have found a security vulnerability that meets our definition of a security 
+If you believe you have found a security vulnerability that meets our definition of a security
 vulnerability, please report is as described below.
 
 ## Context
 
-Please review our [threat model and accepted risks](https://nextcloud.com/security/threat-model) to learn what 
-is currently considered a security vulnerability versus expected behavior. And review what is considered 
+Please review our [threat model and accepted risks](https://nextcloud.com/security/threat-model) to learn what
+is currently considered a security vulnerability versus expected behavior. And review what is considered
 [in scope or bounty eligible](https://hackerone.com/nextcloud/policy_scopes).
 
 
@@ -31,17 +31,17 @@ Your report should include:
 
 You should receive an initial acknowledgement within 24 hours in most cases.
 
-A member of the security team will confirm the vulnerability, determine its impact, follow-up with any questions, 
-and coordinate the fix and publication. 
-
-If the vulnerability involves an app that is not formally maintained by Nextcloud (i.e. hosted by the 
-Nextcloud project but community maintained), the security team will contact the current maintainer 
-and help make sure the issue gets fixed.
+A member of the security team will confirm the vulnerability, determine its impact, follow-up with any questions,
+and coordinate the fix and publication.
 
 The fix will be applied to all applicable and still supported stable branches, tested, and packaged in the next security release.
 The vulnerability will be publicly announced after the release. Finally, your name will be added
-to the [hall of fame](https://hackerone.com/nextcloud/thanks) as a thank you from the entire Nextcloud 
-community. 
+to the [hall of fame](https://hackerone.com/nextcloud/thanks) as a thank you from the entire Nextcloud
+community.
+
+If the vulnerability involves an app that is not maintained by Nextcloud (i.e. hosted by the 
+Nextcloud project but community maintained, or hosted elsewhere), the security team will try to coordinate with the
+current maintainer and help to get the issue fixed in similar fashion.
 
 ### Bug Bounties
 
@@ -51,8 +51,7 @@ on past bounty ranges can be found at [hackerone.com/nextcloud](https://hackeron
 ## Existing Security Advisories
 
 Published security advisories for the Nextcloud Server, Clients and Apps can be viewed at
-[https://github.com/nextcloud/security-advisories/security/advisories](https://github.com/nextcloud/security-advisories/security/advisories
-).
+[https://github.com/nextcloud/security-advisories/security/advisories](https://github.com/nextcloud/security-advisories/security/advisories).
 
 ## Supported Versions
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,26 +1,61 @@
 # Security Policy
 
-## Supported Versions
+[Security](https://nextcloud.com/security/) is very important to us. 
 
-The latest three major release versions of Nextcloud are currently being supported with security updates.
-Please visit https://github.com/nextcloud/server/wiki/Maintenance-and-Release-Schedule for further details.
+If you believe you have found a security vulnerability that meets our definition of a security 
+vulnerability, please report is as described below.
+
+## Context
+
+Please review our [threat model and accepted risks](https://nextcloud.com/security/threat-model) to learn what 
+is currently considered a security vulnerability versus expected behavior. And review what is considered 
+[in scope or bounty eligible](https://hackerone.com/nextcloud/policy_scopes).
+
 
 ## Reporting a Vulnerability
 
-Security is very important to us. If you have discovered a security issue with Nextcloud,
-please read our responsible disclosure guidelines and contact us at [hackerone.com/nextcloud](https://hackerone.com/nextcloud).
+** **Please do _not_ report security vulnerabilities through public GitHub issues.** **
+
+If you have discovered a security matter with Nextcloud, please read our
+[responsible disclosure guidelines](https://nextcloud.com/security/) and contact us at
+[hackerone.com/nextcloud](https://hackerone.com/nextcloud).
+
 Your report should include:
 
 - Product version
 - A vulnerability description
 - Reproduction steps
+- Any other details you think are likely to be important
 
-If in scope of the project a member of the security team will confirm the vulnerability, determine its impact, and develop a fix.
-Otherwise the team will contact the maintainer and make sure the issue gets fixed.
-The fix will be applied to the master branch, tested, and packaged in the next security release.
+### What to Expect
+
+You should receive an initial acknowledgement within 24 hours in most cases.
+
+A member of the security team will confirm the vulnerability, determine its impact, follow-up with any questions, 
+and coordinate the fix and publication.
+
+The fix will be applied to all applicable and still supported stable branches, tested, and packaged in the next security release.
 The vulnerability will be publicly announced after the release. Finally, your name will be added
-to the [hall of fame](https://hackerone.com/nextcloud/thanks) as a thank you from the entire Nextcloud community. Note our
-[threat model](https://nextcloud.com/security/threat-model) to know what is expected behavior.
+to the [hall of fame](https://hackerone.com/nextcloud/thanks) as a thank you from the entire Nextcloud 
+community. 
 
+### Bug Bounties
 
-Please visit https://nextcloud.com/security/ for further information about security.
+If you are reporting for a bug bounty, more complete reports can contribute to a higher bounty award. Details
+on past bounty ranges can be found at [hackerone.com/nextcloud](https://hackerone.com/nextcloud).
+
+## Existing Security Advisories
+
+Published security advisories for the Nextcloud Server, Clients and Apps can be viewed at
+[https://github.com/nextcloud/security-advisories/security/advisories](https://github.com/nextcloud/security-advisories/security/advisories
+).
+
+## Supported Versions
+
+Nextcloud Server major release versions are being supported with security updates for 1 year after their initial release.
+Please visit https://github.com/nextcloud/server/wiki/Maintenance-and-Release-Schedule for further details.
+
+## Additional Information
+
+Please visit [https://nextcloud.com/security/](https://nextcloud.com/security/) for further information about Nextcloud security.
+Please visit [https://nextcloud.com/security/threat-model](https://nextcloud.com/security/threat-model) for our threat model and accepted risks.


### PR DESCRIPTION
Offshoot of nextcloud/server#40966.

One caveat: I think the line added in https://github.com/nextcloud/.github/commit/6c456914c9914c6a352717e2f58bb71cd026aa93 in the existing Security Policy was probably trying to accommodate maybe either some of the "hosted" but still fairly independent sub-projects and/or maybe a way to accommodate reports about third-party maintained apps.

a) Is my guess accurate?
b) Should we try to accommodate that still?
c) If so, maybe we can find a clearer way to state that?

If a/b/c === true then we can add it to this PR before it gets merged if deemed appropriate.