### PR TITLE
automatically determine php/server versions for phpunit

### DIFF
--- a/workflow-templates/phpunit-mariadb.yml
+++ b/workflow-templates/phpunit-mariadb.yml
@@ -23,6 +23,7 @@ jobs:
     steps:
       - name: Checkout app
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
       - name: Get version matrix
         id: versions
         uses: icewind1991/nextcloud-version-matrix@d594a6929da316b732c53355e52a1ead77ba36c7 # v1.2.0

--- a/workflow-templates/phpunit-mariadb.yml
+++ b/workflow-templates/phpunit-mariadb.yml
@@ -15,6 +15,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      php-max: ${{ steps.versions.outputs.php-max-list }}
+      server-max: ${{ steps.versions.outputs.branches-max-list }}
+    steps:
+      - name: Checkout app
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Get version matrix
+        id: versions
+        uses: icewind1991/nextcloud-version-matrix@d594a6929da316b732c53355e52a1ead77ba36c7 # v1.2.0
+
   changes:
     runs-on: ubuntu-latest
 
@@ -42,14 +54,14 @@ jobs:
   phpunit-mariadb:
     runs-on: ubuntu-latest
 
-    needs: changes
+    needs: [changes, matrix]
     if: needs.changes.outputs.src != 'false'
 
     strategy:
       matrix:
-        php-versions: ['8.2']
+        php-versions: ${{ fromJson(needs.matrix.outputs.php-max) }}
+        server-versions: ${{ fromJson(needs.matrix.outputs.server-max) }}
         mariadb-versions: ['10.6', '10.11']
-        server-versions: ['master']
 
     name: MariaDB ${{ matrix.mariadb-versions }} PHP ${{ matrix.php-versions }} Nextcloud ${{ matrix.server-versions }}
 

--- a/workflow-templates/phpunit-mysql.yml
+++ b/workflow-templates/phpunit-mysql.yml
@@ -15,6 +15,19 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.versions.outputs.sparse-matrix }}
+    steps:
+      - name: Checkout app
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Get version matrix
+        id: versions
+        uses: icewind1991/nextcloud-version-matrix@d594a6929da316b732c53355e52a1ead77ba36c7 # v1.2.0
+        with:
+          matrix: '{"mysql-versions": ["8.1"]}'
+
   changes:
     runs-on: ubuntu-latest
 
@@ -42,14 +55,11 @@ jobs:
   phpunit-mysql:
     runs-on: ubuntu-latest
 
-    needs: changes
+    needs: [changes, matrix]
     if: needs.changes.outputs.src != 'false'
 
     strategy:
-      matrix:
-        php-versions: ['8.0', '8.1', '8.2', '8.3']
-        server-versions: ['master']
-        mysql-versions: ['8.1']
+      matrix: ${{ fromJson(needs.matrix.outputs.matrix) }}
 
     name: MySQL ${{ matrix.mysql-versions }} PHP ${{ matrix.php-versions }} Nextcloud ${{ matrix.server-versions }}
 

--- a/workflow-templates/phpunit-mysql.yml
+++ b/workflow-templates/phpunit-mysql.yml
@@ -22,6 +22,7 @@ jobs:
     steps:
       - name: Checkout app
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
       - name: Get version matrix
         id: versions
         uses: icewind1991/nextcloud-version-matrix@d594a6929da316b732c53355e52a1ead77ba36c7 # v1.2.0

--- a/workflow-templates/phpunit-oci.yml
+++ b/workflow-templates/phpunit-oci.yml
@@ -23,6 +23,7 @@ jobs:
     steps:
       - name: Checkout app
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
       - name: Get version matrix
         id: versions
         uses: icewind1991/nextcloud-version-matrix@d594a6929da316b732c53355e52a1ead77ba36c7 # v1.2.0

--- a/workflow-templates/phpunit-oci.yml
+++ b/workflow-templates/phpunit-oci.yml
@@ -15,6 +15,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      php-max: ${{ steps.versions.outputs.php-max-list }}
+      server-max: ${{ steps.versions.outputs.branches-max-list }}
+    steps:
+      - name: Checkout app
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Get version matrix
+        id: versions
+        uses: icewind1991/nextcloud-version-matrix@d594a6929da316b732c53355e52a1ead77ba36c7 # v1.2.0
+
   changes:
     runs-on: ubuntu-latest
 
@@ -42,13 +54,13 @@ jobs:
   phpunit-oci:
     runs-on: ubuntu-22.04
 
-    needs: changes
+    needs: [changes, matrix]
     if: needs.changes.outputs.src != 'false'
 
     strategy:
       matrix:
-        php-versions: ['8.2']
-        server-versions: ['master']
+        php-versions: ${{ fromJson(needs.matrix.outputs.php-max) }}
+        server-versions: ${{ fromJson(needs.matrix.outputs.server-max) }}
 
     services:
       oracle:

--- a/workflow-templates/phpunit-pgsql.yml
+++ b/workflow-templates/phpunit-pgsql.yml
@@ -23,6 +23,7 @@ jobs:
     steps:
       - name: Checkout app
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
       - name: Get version matrix
         id: versions
         uses: icewind1991/nextcloud-version-matrix@d594a6929da316b732c53355e52a1ead77ba36c7 # v1.2.0

--- a/workflow-templates/phpunit-pgsql.yml
+++ b/workflow-templates/phpunit-pgsql.yml
@@ -15,6 +15,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      php-max: ${{ steps.versions.outputs.php-max-list }}
+      server-max: ${{ steps.versions.outputs.branches-max-list }}
+    steps:
+      - name: Checkout app
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Get version matrix
+        id: versions
+        uses: icewind1991/nextcloud-version-matrix@d594a6929da316b732c53355e52a1ead77ba36c7 # v1.2.0
+
   changes:
     runs-on: ubuntu-latest
 
@@ -42,13 +54,13 @@ jobs:
   phpunit-pgsql:
     runs-on: ubuntu-latest
 
-    needs: changes
+    needs: [changes, matrix]
     if: needs.changes.outputs.src != 'false'
 
     strategy:
       matrix:
-        php-versions: ['8.2']
-        server-versions: ['master']
+        php-versions: ${{ fromJson(needs.matrix.outputs.php-max) }}
+        server-versions: ${{ fromJson(needs.matrix.outputs.server-max) }}
 
     services:
       postgres:

--- a/workflow-templates/phpunit-sqlite.yml
+++ b/workflow-templates/phpunit-sqlite.yml
@@ -23,6 +23,7 @@ jobs:
     steps:
       - name: Checkout app
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
       - name: Get version matrix
         id: versions
         uses: icewind1991/nextcloud-version-matrix@d594a6929da316b732c53355e52a1ead77ba36c7 # v1.2.0

--- a/workflow-templates/phpunit-sqlite.yml
+++ b/workflow-templates/phpunit-sqlite.yml
@@ -15,6 +15,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      php-max: ${{ steps.versions.outputs.php-max-list }}
+      server-max: ${{ steps.versions.outputs.branches-max-list }}
+    steps:
+      - name: Checkout app
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Get version matrix
+        id: versions
+        uses: icewind1991/nextcloud-version-matrix@d594a6929da316b732c53355e52a1ead77ba36c7 # v1.2.0
+
   changes:
     runs-on: ubuntu-latest
 
@@ -42,13 +54,13 @@ jobs:
   phpunit-sqlite:
     runs-on: ubuntu-latest
 
-    needs: changes
+    needs: [changes, matrix]
     if: needs.changes.outputs.src != 'false'
 
     strategy:
       matrix:
-        php-versions: ['8.2']
-        server-versions: ['master']
+        php-versions: ${{ fromJson(needs.matrix.outputs.php-max) }}
+        server-versions: ${{ fromJson(needs.matrix.outputs.server-max) }}
 
     steps:
       - name: Set app env


### PR DESCRIPTION
Automatically run sqlite tests against all server versions listed as supported in `info.xml` and the minimum supported php version for the server version.

Example run: https://github.com/nextcloud/files_antivirus/actions/runs/6736095943

(also set `nextcloud/ocp` to not be installed as it is specific to server/php versions and only needed for psalm anyway)