### PR TITLE
fix(psalm): Improve name of psalm action

### DIFF
--- a/workflow-templates/psalm-matrix.yml
+++ b/workflow-templates/psalm-matrix.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         ocp-version: [ 'dev-master', 'dev-stable28', 'dev-stable27', 'dev-stable26' ]
 
-    name: Nextcloud ${{ matrix.ocp-version }}
+    name: static-psalm-analysis ${{ matrix.ocp-version }}
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/workflow-templates/psalm.yml
+++ b/workflow-templates/psalm.yml
@@ -15,7 +15,7 @@ jobs:
   static-analysis:
     runs-on: ubuntu-latest
 
-    name: Nextcloud
+    name: static-psalm-analysis
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1


### PR DESCRIPTION
The name of the psalm multi-branch action to add to the branch protection was `static-psalm-analysis-summary` which is good and logical to find.
The name of the stable branched psalm action was `Nextcloud` which is very little straight forward.