### PR TITLE
enh(workflow-templates): approve and automerge renovate PRs

### DIFF
--- a/workflow-templates/renovate-approve-merge.yml
+++ b/workflow-templates/renovate-approve-merge.yml
@@ -1,0 +1,49 @@
+# This workflow is provided via the organization template repository
+#
+# https://github.com/nextcloud/.github
+# https://docs.github.com/en/actions/learn-github-actions/sharing-workflows-with-your-organization
+
+name: Auto approve renovate PRs
+
+on:
+  pull_request_target:
+    branches:
+      - main
+      - master
+      - stable*
+
+permissions:
+  contents: read
+
+concurrency:
+  group: renovate-approve-merge-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  auto-approve-merge:
+    if: github.actor == 'renovate[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      # for hmarr/auto-approve-action to approve PRs
+      pull-requests: write
+      # for alexwilson/enable-github-automerge-action to approve PRs
+      contents: write
+
+    steps:
+      - uses: mdecoleman/pr-branch-name@bab4c71506bcd299fb350af63bb8e53f2940a599 # v2.0.0
+        id: branchname
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # GitHub actions bot approve
+      - uses: hmarr/auto-approve-action@v3
+        if: startsWith(steps.branchname.outputs.branch, 'renovate/')
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Enable GitHub auto merge
+      - name: Auto merge
+        uses: alexwilson/enable-github-automerge-action@main
+        if: startsWith(steps.branchname.outputs.branch, 'renovate/')
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Similar to `dependabot-approve-merge`
but using the mechanisms of `update-nextcloud-ocp-approve-merge`.

Currently used in `text`, PR pending in `collectives`.