### PR TITLE
fix(command-compile): fix workspace path and compatibility with self-hosted runners

### DIFF
--- a/workflow-templates/command-compile.yml
+++ b/workflow-templates/command-compile.yml
@@ -39,9 +39,9 @@ jobs:
         id: git-path
         run: |
           if ${{ startsWith(steps.command.outputs.arg1, '/') }}; then
-            echo "path=${{ github.workspace }}${{steps.command.outputs.arg1}}" >> $GITHUB_OUTPUT
+            echo "path=${{steps.command.outputs.arg1}}" >> $GITHUB_OUTPUT
           else
-            echo "path=${{ github.workspace }}${{steps.command.outputs.arg2}}" >> $GITHUB_OUTPUT
+            echo "path=${{steps.command.outputs.arg2}}" >> $GITHUB_OUTPUT
           fi
 
       - name: Init branch
@@ -98,21 +98,21 @@ jobs:
       - name: Commit and push default
         if: ${{ needs.init.outputs.arg1 != 'fixup' && needs.init.outputs.arg1 != 'amend' }}
         run: |
-          git add ${{ needs.init.outputs.git_path }}
+          git add ${{ github.workspace }}${{ needs.init.outputs.git_path }}
           git commit --signoff -m 'chore(assets): Recompile assets'
           git push origin ${{ needs.init.outputs.head_ref }}
 
       - name: Commit and push fixup
         if: ${{ needs.init.outputs.arg1 == 'fixup' }}
         run: |
-          git add ${{ needs.init.outputs.git_path }}
+          git add ${{ github.workspace }}${{ needs.init.outputs.git_path }}
           git commit --fixup=HEAD --signoff
           git push origin ${{ needs.init.outputs.head_ref }}
 
       - name: Commit and push amend
         if: ${{ needs.init.outputs.arg1 == 'amend' }}
         run: |
-          git add ${{ needs.init.outputs.git_path }}
+          git add ${{ github.workspace }}${{ needs.init.outputs.git_path }}
           git commit --amend --no-edit --signoff
           git push --force origin ${{ needs.init.outputs.head_ref }}
 


### PR DESCRIPTION
Already in place on server https://github.com/nextcloud/server/blob/master/.github/workflows/command-compile.yml
The workspace path changes and if the init step ran on a different host than the process step, it would fail.

No [failure since a few days](https://github.com/nextcloud/server/actions/workflows/command-compile.yml?query=is%3Afailure) on server because of this