### PR TITLE
fix(npmauditfix): Make commit semantic

### DIFF
--- a/workflow-templates/npm-audit-fix.yml
+++ b/workflow-templates/npm-audit-fix.yml
@@ -60,7 +60,7 @@ jobs:
         uses: peter-evans/create-pull-request@b1ddad2c994a25fbc81a28b3ec0e368bb2021c50 # v5
         with:
           token: ${{ secrets.COMMAND_BOT_PAT }}
-          commit-message: "chore(deps): fix npm audit"
+          commit-message: "fix(deps): fix npm audit"
           committer: GitHub <noreply@github.com>
           author: nextcloud-command <nextcloud-command@users.noreply.github.com>
           signoff: true


### PR DESCRIPTION
Fixing npm audit potentially means the change has effect for the product and requires a fix. Repos that use release automation would skip releases if there are only "chore" commits since the last tag. A security fix should definitely cause a release. The change should also go onto the changelog (again "chore" being typically ignored for this).