### PR TITLE
fix(node-publish): Do not try to publish on Github Registry

### DIFF
--- a/workflow-templates/npm-publish.yml
+++ b/workflow-templates/npm-publish.yml
@@ -55,13 +55,3 @@ jobs:
           npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Setup Github Package Registry
-        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v3
-        with:
-          registry-url: 'https://npm.pkg.github.com'
-
-      - name: Publish package on GPR
-        run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This does not work anymore since we have a second organization. Because our packahes are scope to `@nextcloud` but developed in `@nextcloud-libraries`.