### PR TITLE
fix: check EOL on stable only if beta not available

### DIFF
--- a/workflow-templates/block-merge-eol.yml
+++ b/workflow-templates/block-merge-eol.yml
@@ -34,4 +34,4 @@ jobs:
 
       - name: Checking if ${{ env.server_major }} is EOL
         run: |
-          php -r 'echo json_encode(require_once "config.php");' | jq --arg version "${{ env.server_major }}" '.stable[$version]["100"].eol // .beta[$version]["100"].eol' | grep --silent -i 'false'
+          php -r 'echo json_encode(require_once "config.php");' | jq --arg version "${{ env.server_major }}" '.stable[$version]["100"].eol // .beta[$version]["100"].eol // "NotEOL"' | grep -q "NotEOL"


### PR DESCRIPTION
Regression introduced by nextcloud-releases/updater_server#1014