### PR TITLE
fix(workflow-templates): Adjust duplicate versions steps in OpenAPI workflow

### DIFF
--- a/workflow-templates/openapi.yml
+++ b/workflow-templates/openapi.yml
@@ -20,13 +20,13 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Get php version
-        id: versions
+        id: php_versions
         uses: icewind1991/nextcloud-version-matrix@58becf3b4bb6dc6cef677b15e2fd8e7d48c0908f # v1.3.1
 
       - name: Set up php
         uses: shivammathur/setup-php@a4e22b60bbb9c1021113f2860347b0759f66fe5d # v2
         with:
-          php-version: ${{ steps.versions.outputs.php-available }}
+          php-version: ${{ steps.php_versions.outputs.php-available }}
           extensions: xml
           coverage: none
           ini-file: development
@@ -42,25 +42,25 @@ jobs:
       - name: Read package.json node and npm engines version
         if: steps.check_typescript_openapi.outputs.files_exists == 'true'
         uses: skjnldsv/read-package-engines-version-actions@8205673bab74a63eb9b8093402fd9e0e018663a1 # v2.2
-        id: versions
+        id: node_versions
         # Continue if no package.json
         continue-on-error: true
         with:
           fallbackNode: '^20'
           fallbackNpm: '^10'
 
-      - name: Set up node ${{ steps.versions.outputs.nodeVersion }}
-        if: ${{ steps.versions.outputs.nodeVersion }}
+      - name: Set up node ${{ steps.node_versions.outputs.nodeVersion }}
+        if: ${{ steps.node_versions.outputs.nodeVersion }}
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
-          node-version: ${{ steps.versions.outputs.nodeVersion }}
+          node-version: ${{ steps.node_versions.outputs.nodeVersion }}
 
-      - name: Set up npm ${{ steps.versions.outputs.npmVersion }}
-        if: ${{ steps.versions.outputs.nodeVersion }}
-        run: npm i -g npm@"${{ steps.versions.outputs.npmVersion }}"
+      - name: Set up npm ${{ steps.node_versions.outputs.npmVersion }}
+        if: ${{ steps.node_versions.outputs.nodeVersion }}
+        run: npm i -g npm@"${{ steps.node_versions.outputs.npmVersion }}"
 
       - name: Install dependencies & build
-        if: ${{ steps.versions.outputs.nodeVersion }}
+        if: ${{ steps.node_versions.outputs.nodeVersion }}
         env:
           CYPRESS_INSTALL_BINARY: 0
           PUPPETEER_SKIP_DOWNLOAD: true


### PR DESCRIPTION
If you try using this workflow it will fail because the `versions` step is defined twice.