### PR TITLE
enh(appstore-build-publish): without dev dependencies

### DIFF
--- a/workflow-templates/appstore-build-publish.yml
+++ b/workflow-templates/appstore-build-publish.yml
@@ -92,11 +92,11 @@ jobs:
         # Skip if no package.json
         if: ${{ steps.versions.outputs.nodeVersion }}
         env:
-          CYPRESS_INSTALL_BINARY: 0
+          NODE_ENV: production
         run: |
           cd ${{ env.APP_NAME }}
           npm ci
-          npm run build
+          npm run build --if-present
 
       - name: Check Krankerl config
         id: krankerl


### PR DESCRIPTION
* Do not install any dev dependencies during the build.
* Pass if there is no `build` script. Some apps (*cough*`data_request`*cough*) have a `package.json` just for cypress tests.