### PR TITLE
fix(reuse): Rename the job so it can be easily required on PRs

### DIFF
--- a/workflow-templates/reuse.yml
+++ b/workflow-templates/reuse.yml
@@ -9,10 +9,10 @@
 
 name: REUSE Compliance Check
 
-on: [pull_request]
+on: pull_request
 
 jobs:
-  test:
+  reuse-compliance-check:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4


### PR DESCRIPTION
Before:
![image](https://github.com/nextcloud/.github/assets/213943/15001063-38ea-4f70-8f02-32af73443159)
