### PR TITLE
Create non-community-usernames.txt

### DIFF
--- a/non-community-usernames.txt
+++ b/non-community-usernames.txt
@@ -1,0 +1,7 @@
+nextcloud-command
+nextcloud-android-bot
+MB-Finski
+nc-fkl
+dartcafe
+skjnldsv
+datenangebot

--- a/non-community-usernames.txt.license
+++ b/non-community-usernames.txt.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: Nextcloud
+SPDX-License-Identifier: CC0-1.0


### PR DESCRIPTION
For various automations (e.g. calculating community SLAs, the pr-feedback-action, etc.) we need a blacklist of people that are not community. We've used the handles from nextcloud.com/team so far but that is not an exhaustive list, especially because people that quit are taken off. This is an attempt to make an additional blacklist of github handles that should not be regarded as "community" / "non-company".