### PR TITLE
fix(appstore-build-publish): keep dev dependencies to build frontend 

### DIFF
--- a/workflow-templates/appstore-build-publish.yml
+++ b/workflow-templates/appstore-build-publish.yml
@@ -99,7 +99,7 @@ jobs:
         run: |
           cd ${{ env.APP_NAME }}
           npm ci
-          npm run build
+          npm run build --if-present
 
       - name: Check Krankerl config
         id: krankerl

--- a/workflow-templates/appstore-build-publish.yml
+++ b/workflow-templates/appstore-build-publish.yml
@@ -95,11 +95,11 @@ jobs:
         # Skip if no package.json
         if: ${{ steps.versions.outputs.nodeVersion }}
         env:
-          NODE_ENV: production
+          CYPRESS_INSTALL_BINARY: 0
         run: |
           cd ${{ env.APP_NAME }}
           npm ci
-          npm run build --if-present
+          npm run build
 
       - name: Check Krankerl config
         id: krankerl


### PR DESCRIPTION
- Revert of https://github.com/nextcloud/.github/pull/347
- but keep `--if-present`

Unlink true Node.js apps, in frontend apps separation between `dependencies` and `devDependencies` is often used to separate:
- `dependencies` = runtime libraries used in the frontend app 
- `devDependencies` = development tools including 
  - bundling/compiling
  - testing
  - linting/formatting

Getting rid of dev deps removes not only testing, but also building tools.

Using `NODE_ENV=production` makes sense for Node.js apps, but for Nextcloud frontend apps it breaks building.

## Example

Found by @Antreesy 

https://github.com/nextcloud-releases/spreed/actions/runs/9945797953/job/27474981578

## Alternative solution

In all the apps use `devDependencies` only for testing/development packages and `dependencies` for both production build/compile and frontend libraries.