### PR TITLE
validate app version from info.xml against the tag name in public action

### DIFF
--- a/workflow-templates/appstore-build-publish.yml
+++ b/workflow-templates/appstore-build-publish.yml
@@ -36,6 +36,17 @@ jobs:
         with:
           path: ${{ env.APP_NAME }}
 
+      - name: Get app version number
+        id: app-version
+        uses: skjnldsv/xpath-action@7e6a7c379d0e9abc8acaef43df403ab4fc4f770c # master
+        with:
+          filename: ${{ env.APP_NAME }}/appinfo/info.xml
+          expression: "//info//version/text()"
+
+      - name: Validate app version against tag
+        run: |
+          [ "${{ env.APP_VERSION }}" = "v${{ fromJSON(steps.app-version.outputs.result).version }}" ]
+
       - name: Get appinfo data
         id: appinfo
         uses: skjnldsv/xpath-action@7e6a7c379d0e9abc8acaef43df403ab4fc4f770c # master


### PR DESCRIPTION
Checks that the tag name matching the version defined in the info.xml.

Mainly intended to prevent accidentally creating a release against the wrong branch.

Fixes #305