### PR TITLE
feat(issue-template): Add default templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/1_bug_report.md
@@ -1,0 +1,76 @@
+---
+name: 🐞 Bug report
+about: Help us to improve by reporting a bug
+labels: 0. Needs triage, bug
+---
+
+<!--- Please keep this note for other contributors -->
+
+### How to use GitHub
+
+* Please use the 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to show that you are affected by the same issue.
+* Please don't comment if you have no relevant information to add. It's just extra noise for everyone subscribed to this issue.
+* Subscribe to receive notifications on status change and new comments.
+
+---
+
+### Steps to reproduce
+1.
+2.
+3.
+
+### Expected behaviour
+Tell us what should happen
+
+### Actual behaviour
+Tell us what happens instead, if possible also add a screenshot
+
+### Server configuration
+
+**Web server:** Apache/Nginx
+
+**Database:** MySQL/Maria/SQLite/PostgreSQL
+
+**PHP version:** 8.1/8.2/8.3
+
+**Nextcloud version:** (see Nextcloud admin page)
+
+<details>
+<summary>List of activated apps</summary>
+
+```
+If you have access to your command line run e.g.:
+sudo -u www-data php occ app:list
+from within your Nextcloud installation folder
+```
+</details>
+
+<details>
+<summary>Nextcloud configuration</summary>
+
+```
+If you have access to your command line run e.g.:
+sudo -u www-data php occ config:list system
+from within your Nextcloud installation folder
+```
+</details>
+
+### Browser
+
+**Browser name:** Firefox/Chrome/Safari/…
+
+**Browser version:** 124/125/…
+
+**Operating system:** Windows/Ubuntu/Mac/…
+
+<details>
+<summary>Browser log</summary>
+
+```
+Insert your browser log here, this could for example include:
+a) The javascript console log
+b) The network log
+c) ...
+```
+
+</details>

--- a/.github/ISSUE_TEMPLATE/2_feature_request.md
+++ b/.github/ISSUE_TEMPLATE/2_feature_request.md
@@ -1,0 +1,31 @@
+---
+name: 🚀 Feature request
+about: Suggest an idea for this app
+labels: 0. Needs triage, enhancement
+---
+
+<!--- Please keep this note for other contributors -->
+
+### How to use GitHub
+
+* Please use the 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to show that you are interested into the same feature.
+* Please don't comment if you have no relevant information to add. It's just extra noise for everyone subscribed to this issue.
+* Subscribe to receive notifications on status change and new comments.
+
+---
+
+## Feature request
+
+**Which Nextcloud Version are you currently using:** (see administration page)
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
Seems that when adding the config with links only, there is no default option for bug reporting anymore (only the "without template" at the end):
> ![grafik](https://github.com/user-attachments/assets/67681daf-98b1-46e9-9435-0f99efadc283)

So adding a very basic simple template now.

In agreement with @AndyScherzinger the default template must be kept very simple and empty-reporting should be enabled