### PR TITLE
fix(workflow-templates): Only run pr-feedback on the nextcloud org

### DIFF
--- a/workflow-templates/pr-feedback.yml
+++ b/workflow-templates/pr-feedback.yml
@@ -17,6 +17,7 @@ on:
 
 jobs:
   pr-feedback:
+    if: ${{ github.repository_owner == 'nextcloud' }}
     runs-on: ubuntu-latest
     steps:
       - name: The get-github-handles-from-website action


### PR DESCRIPTION
Avoid running it on the gmbh org or any other place where we don't want to post the feedback comments.