### PR TITLE
fix: set up minimum supported instead of available php version

### DIFF
--- a/workflow-templates/lint-php-cs.yml
+++ b/workflow-templates/lint-php-cs.yml
@@ -31,10 +31,10 @@ jobs:
         id: versions
         uses: icewind1991/nextcloud-version-matrix@58becf3b4bb6dc6cef677b15e2fd8e7d48c0908f # v1.3.1
 
-      - name: Set up php${{ steps.versions.outputs.php-available }}
+      - name: Set up php${{ steps.versions.outputs.php-min }}
         uses: shivammathur/setup-php@c541c155eee45413f5b09a52248675b1a2575231 # v2.31.1
         with:
-          php-version: ${{ steps.versions.outputs.php-available }}
+          php-version: ${{ steps.versions.outputs.php-min }}
           extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite
           coverage: none
           ini-file: development

--- a/workflow-templates/psalm.yml
+++ b/workflow-templates/psalm.yml
@@ -27,10 +27,10 @@ jobs:
         id: versions
         uses: icewind1991/nextcloud-version-matrix@58becf3b4bb6dc6cef677b15e2fd8e7d48c0908f # v1.3.1
 
-      - name: Set up php${{ steps.versions.outputs.php-available }}
+      - name: Set up php${{ steps.versions.outputs.php-min }}
         uses: shivammathur/setup-php@c541c155eee45413f5b09a52248675b1a2575231 # v2.31.1
         with:
-          php-version: ${{ steps.versions.outputs.php-available }}
+          php-version: ${{ steps.versions.outputs.php-min }}
           extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite
           coverage: none
           ini-file: development


### PR DESCRIPTION
Follow-up to https://github.com/nextcloud/.github/pull/458

They are currently installing PHP 8.4 but [PHP-CS-Fixer](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer?tab=readme-ov-file#supported-php-versions) and [Psalm](https://github.com/vimeo/psalm/issues/11107) are not yet compatible.

AFAIK, `php-available` is kind of a performance optimization. On the other hand, this blocks CI on apps until PHP 8.4 is ready for production.

### Cs-fixer
Failing workflow: https://github.com/nextcloud/twofactor_totp/actions/runs/11918557008/job/33216257705?pr=1580
Fixed workflow: https://github.com/nextcloud/twofactor_totp/actions/runs/11919662884/job/33219864123?pr=1580

### Psalm
Failing workflow: https://github.com/nextcloud/twofactor_totp/actions/runs/11919662892/job/33219863665?pr=1580
Fixed workflow: https://github.com/nextcloud/twofactor_totp/actions/runs/11919806670/job/33220330966?pr=1581