### PR TITLE
fix(psalm): Enforce that psalm is executed against the minimum PHP version

### DIFF
--- a/workflow-templates/psalm-matrix.yml
+++ b/workflow-templates/psalm-matrix.yml
@@ -19,13 +19,16 @@ jobs:
     runs-on: ubuntu-latest-low
     outputs:
       ocp-matrix: ${{ steps.versions.outputs.ocp-matrix }}
-      php-min: ${{ steps.versions.outputs.php-min }}
     steps:
       - name: Checkout app
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
       - name: Get version matrix
         id: versions
         uses: icewind1991/nextcloud-version-matrix@58becf3b4bb6dc6cef677b15e2fd8e7d48c0908f # v1.3.1
+
+      - name: Check enforcement of minimum PHP version ${{ steps.versions.outputs.php-min }} in psalm.xml
+        run: grep 'phpVersion="${{ steps.versions.outputs.php-min }}' psalm.xml
 
   static-analysis:
     runs-on: ubuntu-latest
@@ -40,10 +43,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Set up php${{ needs.matrix.outputs.php-min }}
+      - name: Set up php${{ matrix.php-versions }}
         uses: shivammathur/setup-php@c541c155eee45413f5b09a52248675b1a2575231 # v2.31.1
         with:
-          php-version: ${{ needs.matrix.outputs.php-min }}
+          php-version: ${{ matrix.php-versions }}
           extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite
           coverage: none
           ini-file: development

--- a/workflow-templates/psalm.yml
+++ b/workflow-templates/psalm.yml
@@ -27,10 +27,13 @@ jobs:
         id: versions
         uses: icewind1991/nextcloud-version-matrix@58becf3b4bb6dc6cef677b15e2fd8e7d48c0908f # v1.3.1
 
-      - name: Set up php${{ steps.versions.outputs.php-min }}
+      - name: Check enforcement of minimum PHP version ${{ steps.versions.outputs.php-min }} in psalm.xml
+        run: grep 'phpVersion="${{ steps.versions.outputs.php-min }}' psalm.xml
+
+      - name: Set up php${{ steps.versions.outputs.php-available }}
         uses: shivammathur/setup-php@c541c155eee45413f5b09a52248675b1a2575231 # v2.31.1
         with:
-          php-version: ${{ steps.versions.outputs.php-min }}
+          php-version: ${{ steps.versions.outputs.php-available }}
           extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite
           coverage: none
           ini-file: development


### PR DESCRIPTION
As discussed the other day with @st3iny 

@st3iny 
> Sounds good, but psalm will probably take some more time: https://github.com/vimeo/psalm/issues/11107

@nickvergessen 
> https://github.com/nextcloud/spreed/actions/runs/11930485130/job/33251359582 talk psalm works on 8.4
it doesnt have a hardcoded version check breaking it
might of course depend on edge cases your code triggers
but I would think Talk is pretty edgy

@st3iny 
> There are some deprecation warnings and it broke in one of my maintained apps though
Can't remember which one


@nickvergessen 
> the other fix for psalm is making sure you have the correct base version
https://github.com/nextcloud/spreed/blob/main/psalm.xml#L8
otherwise it checks your code to only be compatible with the actually used php version
instead of the minimum
we should add a grep call to the ci workflow, to make sure the phpversion is added


### psalm.xml
- :green_circle: https://github.com/nextcloud/files_retention/pull/678
- :red_circle: https://github.com/nextcloud/files_retention/pull/679

### psalm-matrix.xml
- :green_circle: https://github.com/nextcloud/call_summary_bot/pull/100
- :red_circle: https://github.com/nextcloud/call_summary_bot/pull/101