### PR TITLE
fix(psalm): Allow to have psalm command with multi-thread support

### DIFF
--- a/workflow-templates/psalm-matrix.yml
+++ b/workflow-templates/psalm-matrix.yml
@@ -63,7 +63,7 @@ jobs:
         run: composer require --dev 'nextcloud/ocp:${{ matrix.ocp-version }}' --ignore-platform-reqs --with-dependencies
 
       - name: Run coding standards check
-        run: composer run psalm
+        run: composer run psalm -- --threads=1 --monochrome --no-progress --output-format=github
 
   summary:
     runs-on: ubuntu-latest-low

--- a/workflow-templates/psalm.yml
+++ b/workflow-templates/psalm.yml
@@ -49,4 +49,4 @@ jobs:
         run: composer require --dev nextcloud/ocp:dev-${{ steps.versions.outputs.branches-max }} --ignore-platform-reqs --with-dependencies
 
       - name: Run coding standards check
-        run: composer run psalm
+        run: composer run psalm -- --threads=1 --monochrome --no-progress --output-format=github


### PR DESCRIPTION
Following the server repo, this allows all apps to deduplicate:
```
		"psalm": "psalm --threads=1",
		"psalm:dev": "psalm --no-cache --threads=$(nproc)",
```

`psalm` exists in all apps, so that's what most devs run first, but if it's single thread it can be very slow.
With this change, CI will overwrite it to be single thread but the default dev environment will still use all threads and you don't need to memorize which app requires you to run `psalm` or `psalm:dev` for it.