### PR TITLE
Revert "fix(reuse): compile before checking compliance"

### DIFF
--- a/workflow-templates/reuse.yml
+++ b/workflow-templates/reuse.yml
@@ -20,27 +20,5 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Read package.json node and npm engines version
-        uses: skjnldsv/read-package-engines-version-actions@06d6baf7d8f41934ab630e97d9e6c0bc9c9ac5e4 # v3
-        id: versions
-        with:
-          fallbackNode: '^20'
-          fallbackNpm: '^10'
-
-      - name: Set up node ${{ steps.versions.outputs.nodeVersion }}
-        uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
-        with:
-          node-version: ${{ steps.versions.outputs.nodeVersion }}
-
-      - name: Set up npm ${{ steps.versions.outputs.npmVersion }}
-        run: npm i -g 'npm@${{ steps.versions.outputs.npmVersion }}'
-
-      - name: Install dependencies & build
-        env:
-          CYPRESS_INSTALL_BINARY: 0
-        run: |
-          npm ci
-          npm run build --if-present
-
       - name: REUSE Compliance Check
         uses: fsfe/reuse-action@bb774aa972c2a89ff34781233d275075cbddf542 # v5.0.0


### PR DESCRIPTION
Reverts nextcloud/.github#478

As brought up by https://github.com/nextcloud/.github/pull/478#issuecomment-2556555950 this breaks repos without compiled js