### PR TITLE
fix(command-compile): persist-credentials for compile bot to allow rebae and force push

### DIFF
--- a/workflow-templates/command-compile.yml
+++ b/workflow-templates/command-compile.yml
@@ -102,7 +102,8 @@ jobs:
       - name: Checkout ${{ needs.init.outputs.head_ref }}
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          persist-credentials: false
+          # Needed to allow force push later
+          persist-credentials: true
           token: ${{ secrets.COMMAND_BOT_PAT }}
           fetch-depth: 0
           ref: ${{ needs.init.outputs.head_ref }}


### PR DESCRIPTION
https://github.com/nextcloud/server/commit/69b4a6cc19683769a92ebbdb0a687cde48ad0ffb
https://github.com/nextcloud/server/actions/runs/12784402160/job/35637333846?pr=50172