### PR TITLE
fix: Update MariaDB versions to supported versions of Nextcloud 31

### DIFF
--- a/workflow-templates/phpunit-mariadb.yml
+++ b/workflow-templates/phpunit-mariadb.yml
@@ -70,7 +70,7 @@ jobs:
       matrix:
         php-versions: ${{ fromJson(needs.matrix.outputs.php-version) }}
         server-versions: ${{ fromJson(needs.matrix.outputs.server-max) }}
-        mariadb-versions: ['10.6', '10.11']
+        mariadb-versions: ['10.6', '11.4']
 
     name: MariaDB ${{ matrix.mariadb-versions }} PHP ${{ matrix.php-versions }} Nextcloud ${{ matrix.server-versions }}
 


### PR DESCRIPTION
For the upcoming release we should make sure to test the supported versions.
Lower bound is 10.6 and upper bound is 11.4