### PR TITLE
fix(npm-publish): Do not require admin permissions

### DIFF
--- a/workflow-templates/npm-publish.yml
+++ b/workflow-templates/npm-publish.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Check actor permission level
         uses: skjnldsv/check-actor-permission@69e92a3c4711150929bca9fcf34448c5bf5526e7 # v3.0
         with:
-          require: admin
+          require: write
 
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
One of the reasons why we have nextcloud-libraries was to restrict permissions. So there is no reason only organization admins can publish. This was a problem in the past for creating new releases.