### PR TITLE
fix(phpunit-mariadb): Use correct script name and env variable

### DIFF
--- a/workflow-templates/phpunit-mariadb.yml
+++ b/workflow-templates/phpunit-mariadb.yml
@@ -80,8 +80,8 @@ jobs:
         ports:
           - 4444:3306/tcp
         env:
-          MYSQL_ROOT_PASSWORD: rootpassword
-        options: --health-cmd="mysqladmin ping" --health-interval 5s --health-timeout 2s --health-retries 5
+          MARIADB_ROOT_PASSWORD: rootpassword
+        options: --health-cmd="mariadb-admin ping" --health-interval 5s --health-timeout 2s --health-retries 5
 
     steps:
       - name: Set app env


### PR DESCRIPTION
In MariaDB 11 there was a "breaking" change in the docker files that removed the legacy `mysqladm` and replaced it with `mariadb-admin`. The symlink is not provided in the docker image so we need to use the correct name here to make 10.6 AND 11.4 work.

Also the `MYSQL_` env variables are deprecated and will be removed.

---

Alternative for the first change would be to use the `healthcheck.sh` provided by the image, but that requires us to rebuild all mariadb images as it was added in later version for 10.2 / 10.3 / 10.4 / 10.5 and 10.6. It is already included in our 11.4 image though.