### PR TITLE
fix: Use normal container for cypress init

### DIFF
--- a/workflow-templates/cypress.yml
+++ b/workflow-templates/cypress.yml
@@ -30,7 +30,7 @@ permissions:
 
 jobs:
   init:
-    runs-on: ubuntu-latest-low
+    runs-on: ubuntu-latest
     outputs:
       nodeVersion: ${{ steps.versions.outputs.nodeVersion }}
       npmVersion: ${{ steps.versions.outputs.npmVersion }}


### PR DESCRIPTION
Needed as we are compiling the front end during that step.

This is a limitation for photos where I need to fix that when I update the workflows.