### PR TITLE
fix(psalm): Run matrix psalm on the lowest applicable PHP version

### DIFF
--- a/workflow-templates/psalm-matrix.yml
+++ b/workflow-templates/psalm-matrix.yml
@@ -50,10 +50,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up php${{ matrix.php-versions }}
+      - name: Set up php${{ matrix.php-min }}
         uses: shivammathur/setup-php@9e72090525849c5e82e596468b86eb55e9cc5401 # v2.32.0
         with:
-          php-version: ${{ matrix.php-versions }}
+          php-version: ${{ matrix.php-min }}
           extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite
           coverage: none
           ini-file: development


### PR DESCRIPTION
As we might not be able to upgrade psalm 6 and 8.4 e.g. complains when using Psalm 5.26 about missing nullable typehints