### PR TITLE
fix: use more conventional commit message for workflow updates

### DIFF
--- a/.github/workflows/dispatch-workflow.yml
+++ b/.github/workflows/dispatch-workflow.yml
@@ -88,11 +88,11 @@ jobs:
         with:
           body: 'Automated update of the ${{ github.event.inputs.name }} workflow from https://github.com/${{ github.repository }}'
           branch: 'feat/workflow-auto-update-${{ github.event.inputs.name }}'
-          commit-message: 'chore(CI): Updating ${{ github.event.inputs.name }} workflow from template'
+          commit-message: 'ci: update ${{ github.event.inputs.name }} workflow from template'
           committer: Nextcloud bot <bot@nextcloud.com>
           author: Nextcloud bot <bot@nextcloud.com>
           path: target
           signoff: true
-          title: 'chore(CI): Updating ${{ github.event.inputs.name }} workflow from template'
+          title: 'ci: update ${{ github.event.inputs.name }} workflow from template'
           labels: dependencies
           token: ${{ secrets.TEMPLATE_WORKFLOW_DISPATCH_PAT }}


### PR DESCRIPTION
1. There is a common type `ci` for changes to CI
2. Simplify verb
3. Lower case description

Ref https://www.conventionalcommits.org/en/v1.0.0/#summary