### PR TITLE
ci: run psalm stets with lowest compatible ocp-package

### DIFF
--- a/workflow-templates/psalm.yml
+++ b/workflow-templates/psalm.yml
@@ -53,7 +53,7 @@ jobs:
           composer i
 
       - name: Install nextcloud/ocp
-        run: composer require --dev nextcloud/ocp:dev-${{ steps.versions.outputs.branches-max }} --ignore-platform-reqs --with-dependencies
+        run: composer require --dev nextcloud/ocp:dev-${{ steps.versions.outputs.branches-min }} --ignore-platform-reqs --with-dependencies
 
       - name: Run coding standards check
         run: composer run psalm -- --threads=1 --monochrome --no-progress --output-format=github


### PR DESCRIPTION
- for apps the run against one major version per branch nothing changes
- for apps that are compatible with multiple apps, the lowest common determinator has to be used. E.g. it fails hard against deprecations.