### PR TITLE
fix: Do not update dependencies in vendor-bin when removing nextcloud/ocp

### DIFF
--- a/workflow-templates/lint-php-cs.yml
+++ b/workflow-templates/lint-php-cs.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer remove nextcloud/ocp --dev
+          composer remove nextcloud/ocp --dev --no-scripts
           composer i
 
       - name: Lint

--- a/workflow-templates/phpunit-mariadb.yml
+++ b/workflow-templates/phpunit-mariadb.yml
@@ -126,7 +126,7 @@ jobs:
         if: steps.check_composer.outputs.files_exists == 'true'
         working-directory: apps/${{ env.APP_NAME }}
         run: |
-          composer remove nextcloud/ocp --dev
+          composer remove nextcloud/ocp --dev --no-scripts
           composer i
 
       - name: Set up Nextcloud

--- a/workflow-templates/phpunit-mysql.yml
+++ b/workflow-templates/phpunit-mysql.yml
@@ -124,7 +124,7 @@ jobs:
         if: steps.check_composer.outputs.files_exists == 'true'
         working-directory: apps/${{ env.APP_NAME }}
         run: |
-          composer remove nextcloud/ocp --dev
+          composer remove nextcloud/ocp --dev --no-scripts
           composer i
 
       - name: Set up Nextcloud

--- a/workflow-templates/phpunit-oci.yml
+++ b/workflow-templates/phpunit-oci.yml
@@ -132,7 +132,7 @@ jobs:
         if: steps.check_composer.outputs.files_exists == 'true'
         working-directory: apps/${{ env.APP_NAME }}
         run: |
-          composer remove nextcloud/ocp --dev
+          composer remove nextcloud/ocp --dev --no-scripts
           composer i
 
       - name: Set up Nextcloud

--- a/workflow-templates/phpunit-pgsql.yml
+++ b/workflow-templates/phpunit-pgsql.yml
@@ -122,7 +122,7 @@ jobs:
         if: steps.check_composer.outputs.files_exists == 'true'
         working-directory: apps/${{ env.APP_NAME }}
         run: |
-          composer remove nextcloud/ocp --dev
+          composer remove nextcloud/ocp --dev --no-scripts
           composer i
 
       - name: Set up Nextcloud

--- a/workflow-templates/phpunit-sqlite.yml
+++ b/workflow-templates/phpunit-sqlite.yml
@@ -111,7 +111,7 @@ jobs:
         if: steps.check_composer.outputs.files_exists == 'true'
         working-directory: apps/${{ env.APP_NAME }}
         run: |
-          composer remove nextcloud/ocp --dev
+          composer remove nextcloud/ocp --dev --no-scripts
           composer i
 
       - name: Set up Nextcloud

--- a/workflow-templates/psalm-matrix.yml
+++ b/workflow-templates/psalm-matrix.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer remove nextcloud/ocp --dev
+          composer remove nextcloud/ocp --dev --no-scripts
           composer i
 
 

--- a/workflow-templates/psalm.yml
+++ b/workflow-templates/psalm.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer remove nextcloud/ocp --dev
+          composer remove nextcloud/ocp --dev --no-scripts
           composer i
 
       - name: Install nextcloud/ocp


### PR DESCRIPTION
Fixes https://github.com/nextcloud/.github/issues/537

The `--no-scripts` option ensures the `post-update-cmd` from the composer-bin plugin is not executed, so only the main composer.lock file will be updated. There doesn't seem to be a proper way to disable command forwarding for single commands with the composer-bin plugin.