### PR TITLE
chore(deps): bump pr-feedback-action, bump start-date value to prevent spam

### DIFF
--- a/workflow-templates/pr-feedback.yml
+++ b/workflow-templates/pr-feedback.yml
@@ -36,7 +36,7 @@ jobs:
           blocklist=$(curl https://raw.githubusercontent.com/nextcloud/.github/master/non-community-usernames.txt | paste -s -d, -)
           echo "blocklist=$blocklist" >> "$GITHUB_OUTPUT"
 
-      - uses: nextcloud/pr-feedback-action@1883b38a033fb16f576875e0cf45f98b857655c4 # main
+      - uses: nextcloud/pr-feedback-action@d7257d0e6298aace6a627c796390c5490f6be33b # main
         with:
           feedback-message: |
             Hello there,
@@ -50,6 +50,6 @@ jobs:
 
             (If you believe you should not receive this message, you can add yourself to the [blocklist](https://github.com/nextcloud/.github/blob/master/non-community-usernames.txt).)
           days-before-feedback: 14
-          start-date: '2024-04-30'
+          start-date: '2025-06-12'
           exempt-authors: '${{ steps.blocklist.outputs.blocklist }},${{ steps.scrape.outputs.users }}'
           exempt-bots: true


### PR DESCRIPTION
- `nextcloud/pr-feedback-action` version bump includes https://github.com/nextcloud/pr-feedback-action/pull/2.
- Start date is bumped for a same reason as in https://github.com/nextcloud/.github/commit/d7257d0e6298aace6a627c796390c5490f6be33b.