### PR TITLE
ci(ocp): Remove hardcoded names from matrix OCP branch updates

### DIFF
--- a/workflow-templates/update-nextcloud-ocp-matrix.yml
+++ b/workflow-templates/update-nextcloud-ocp-matrix.yml
@@ -24,8 +24,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branches: ['master']
-        target: ['stable30']
+        branches:
+          - ${{ github.event.repository.default_branch }}
 
     name: update-nextcloud-ocp-${{ matrix.branches }}
 
@@ -35,6 +35,10 @@ jobs:
           persist-credentials: false
           ref: ${{ matrix.branches }}
           submodules: true
+
+      - name: Get version matrix
+        id: versions
+        uses: icewind1991/nextcloud-version-matrix@58becf3b4bb6dc6cef677b15e2fd8e7d48c0908f # v1.3.1
 
       - name: Set up php8.2
         uses: shivammathur/setup-php@0f7f1d08e3e32076e51cae65eb0b0c871405b16e # v2.34.1
@@ -57,7 +61,7 @@ jobs:
 
       - name: Composer update nextcloud/ocp
         id: update_branch
-        run: composer require --dev nextcloud/ocp:dev-${{ matrix.target }}
+        run: composer require --dev nextcloud/ocp:dev-${{ steps.versions.outputs.branches-min }}
 
       - name: Raise on issue on failure
         uses: dacbd/create-issue-action@cdb57ab6ff8862aa09fee2be6ba77a59581921c2 # v2.0.0


### PR DESCRIPTION
- Default instead of hardcoded master/main (idea stolen from #561 )
- Use version matrix to calculate the target branch
- …
- Profit: No more diff when updating this action in apps that support a different oldest branch and use main