### PR TITLE
ci(zizmor): Ignore new warning from zizmor 1.11

### DIFF
--- a/workflow-templates/update-nextcloud-ocp.yml
+++ b/workflow-templates/update-nextcloud-ocp.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Composer update nextcloud/ocp
         id: update_branch
         if: ${{ steps.checkout.outcome == 'success' && matrix.branches != 'main' }}
-        run: composer require --dev 'nextcloud/ocp:dev-${{ matrix.branches }}'
+        run: composer require --dev 'nextcloud/ocp:dev-${{ matrix.branches }}' # zizmor: ignore[template-injection]
 
       - name: Raise on issue on failure
         uses: dacbd/create-issue-action@cdb57ab6ff8862aa09fee2be6ba77a59581921c2 # v2.0.0


### PR DESCRIPTION
Save to ignore in this case as:
- It's only running in a cron on the same repository
- The list of branches is hardcoded