### PR TITLE
fix(command-compile): disable editing commit when rebasing

### DIFF
--- a/workflow-templates/command-compile.yml
+++ b/workflow-templates/command-compile.yml
@@ -161,8 +161,8 @@ jobs:
                 echo "No changes after conflict resolution, skipping commit"
                 git rebase --skip
               else
-                echo "Changes found, continuing rebase"
-                git rebase --continue
+                echo "Changes found, continuing rebase without editing commit message"
+                git -c core.editor=true rebase --continue
               fi
               
               # Break if rebase is complete


### PR DESCRIPTION
Sometimes it fails because it asks for the editor.
This disables it and make it non interactive 