### PR TITLE
fix(dependabot): Remove unsupported versioning-strategy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,6 @@ updates:
     commit-message:
       prefix: "build"
       include: "scope"
-    versioning-strategy: "increase"
     schedule:
       interval: daily
       time: "03:00"
@@ -24,7 +23,6 @@ updates:
     commit-message:
       prefix: "ci"
       include: "scope"
-    versioning-strategy: "increase"
     schedule:
       interval: weekly
       day: saturday


### PR DESCRIPTION
According to https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#versioning-strategy-- this is no longer supported for `github-actions`
Error is shown in https://github.com/nextcloud/.github/pull/408/checks?check_run_id=47264157022