### PR TITLE
fix(eol): EOL now include day in major versions desc

### DIFF
--- a/workflow-templates/block-merge-eol.yml
+++ b/workflow-templates/block-merge-eol.yml
@@ -37,13 +37,13 @@ jobs:
             if (match) {
               console.log('Setting server_major to ' + match[1]);
               core.exportVariable('server_major', match[1]);
-              console.log('Setting current_month to ' + (new Date()).toISOString().substr(0, 7));
-              core.exportVariable('current_month', (new Date()).toISOString().substr(0, 7));
+              console.log('Setting current_day to ' + (new Date()).toISOString().substr(0, 10));
+              core.exportVariable('current_day', (new Date()).toISOString().substr(0, 10));
             }
 
       - name: Checking if server ${{ env.server_major }} is EOL
         if: ${{ env.server_major != '' }}
         run: |
           curl -s https://raw.githubusercontent.com/nextcloud-releases/updater_server/production/config/major_versions.json \
-            | jq '.["${{ env.server_major }}"]["eol"] // "9999-99" | . >= "${{ env.current_month }}"' \
+            | jq '.["${{ env.server_major }}"]["eol"] // "9999-99-99" | . >= "${{ env.current_day }}"' \
             | grep -q true


### PR DESCRIPTION
Since https://github.com/nextcloud-releases/updater_server/pull/1082 day is included in `major_versions.json`.
This fix account for it