### PR TITLE
fix(ci): remove redundant renovate[bot] check from dependabot-approve-merge workflow

### DIFF
--- a/workflow-templates/dependabot-approve-merge.yml
+++ b/workflow-templates/dependabot-approve-merge.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   auto-approve-merge:
-    if: github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'renovate[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest-low
     permissions:
       # for hmarr/auto-approve-action to approve PRs


### PR DESCRIPTION
This PR removes the `renovate[bot]` trigger from the `dependabot-approve-merge.yml` workflow to eliminate unnecessary runner usage and improve clarity. This condition was added in #324, but is currently redundant.

Why?

* A dedicated `renovate-approve-merge.yml` workflow already exists.
* The job's inner steps are hardcoded to skip unless the branch starts with `dependabot/`, making Renovate triggers ineffective.
* Prevents unnecessary job runs for every Renovate PR.