### PR TITLE
ci(cmd-compile): use persist-credentials: false and env indirection

### DIFF
--- a/workflow-templates/command-compile.yml
+++ b/workflow-templates/command-compile.yml
@@ -211,7 +211,7 @@ jobs:
         if: ${{ !contains(needs.init.outputs.arg1, 'rebase') && !contains(needs.init.outputs.arg1, 'amend') }}
         env:
           HEAD_REF: ${{ needs.init.outputs.head_ref }}
-          BOT_TOKEN: ${{ secrets.COMMAND_BOT_PAT }}
+          BOT_TOKEN: ${{ secrets.COMMAND_BOT_PAT }}  # zizmor: ignore[secrets-outside-env]
         run: |
           git remote set-url origin "https://x-access-token:${BOT_TOKEN}@github.com/${{ github.repository }}.git"
           git push origin "$HEAD_REF"
@@ -220,7 +220,7 @@ jobs:
         if: ${{ contains(needs.init.outputs.arg1, 'rebase') || contains(needs.init.outputs.arg1, 'amend') }}
         env:
           HEAD_REF: ${{ needs.init.outputs.head_ref }}
-          BOT_TOKEN: ${{ secrets.COMMAND_BOT_PAT }}
+          BOT_TOKEN: ${{ secrets.COMMAND_BOT_PAT }}  # zizmor: ignore[secrets-outside-env]
         run: |
           git remote set-url origin "https://x-access-token:${BOT_TOKEN}@github.com/${{ github.repository }}.git"
           git push --force-with-lease origin "$HEAD_REF"

--- a/workflow-templates/command-compile.yml
+++ b/workflow-templates/command-compile.yml
@@ -105,8 +105,7 @@ jobs:
       - name: Checkout ${{ needs.init.outputs.head_ref }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          # Needed to allow force push later
-          persist-credentials: true
+          persist-credentials: false
           token: ${{ secrets.COMMAND_BOT_PAT }} # zizmor: ignore[secrets-outside-env]
           fetch-depth: 0
           ref: ${{ needs.init.outputs.head_ref }}
@@ -134,11 +133,13 @@ jobs:
 
       - name: Rebase to ${{ needs.init.outputs.base_ref }}
         if: ${{ contains(needs.init.outputs.arg1, 'rebase') }}
+        env:
+          BASE_REF: ${{ needs.init.outputs.base_ref }}
         run: |
-          git fetch origin '${{ needs.init.outputs.base_ref }}:${{ needs.init.outputs.base_ref }}'
+          git fetch origin "${BASE_REF}:${BASE_REF}"
 
           # Start the rebase
-          git rebase 'origin/${{ needs.init.outputs.base_ref }}' || {
+          git rebase "origin/${BASE_REF}" || {
             # Handle rebase conflicts in a loop
             while [ -d .git/rebase-merge ] || [ -d .git/rebase-apply ]; do
               echo "Handling rebase conflict..."
@@ -146,11 +147,11 @@ jobs:
               # Remove and checkout /dist and /js folders from the base branch
               if [ -d "dist" ]; then
                 rm -rf dist
-                git checkout origin/${{ needs.init.outputs.base_ref }} -- dist/ 2>/dev/null || echo "No dist folder in base branch"
+                git checkout "origin/${BASE_REF}" -- dist/ 2>/dev/null || echo "No dist folder in base branch"
               fi
               if [ -d "js" ]; then
                 rm -rf js
-                git checkout origin/${{ needs.init.outputs.base_ref }} -- js/ 2>/dev/null || echo "No js folder in base branch"
+                git checkout "origin/${BASE_REF}" -- js/ 2>/dev/null || echo "No js folder in base branch"
               fi
 
               # Stage all changes
@@ -182,20 +183,26 @@ jobs:
 
       - name: Commit default
         if: ${{ !contains(needs.init.outputs.arg1, 'fixup') && !contains(needs.init.outputs.arg1, 'amend') }}
+        env:
+          GIT_PATH: ${{ needs.init.outputs.git_path }}
         run: |
-          git add '${{ github.workspace }}${{ needs.init.outputs.git_path }}'
+          git add "${GITHUB_WORKSPACE}${GIT_PATH}"
           git commit --signoff -m 'chore(assets): Recompile assets'
 
       - name: Commit fixup
         if: ${{ contains(needs.init.outputs.arg1, 'fixup') }}
+        env:
+          GIT_PATH: ${{ needs.init.outputs.git_path }}
         run: |
-          git add '${{ github.workspace }}${{ needs.init.outputs.git_path }}'
+          git add "${GITHUB_WORKSPACE}${GIT_PATH}"
           git commit --fixup=HEAD --signoff
 
       - name: Commit amend
         if: ${{ contains(needs.init.outputs.arg1, 'amend') }}
+        env:
+          GIT_PATH: ${{ needs.init.outputs.git_path }}
         run: |
-          git add '${{ github.workspace }}${{ needs.init.outputs.git_path }}'
+          git add "${GITHUB_WORKSPACE}${GIT_PATH}"
           git commit --amend --no-edit --signoff
           # Remove any [skip ci] from the amended commit
           git commit --amend -m "$(git log -1 --format='%B' | sed '/\[skip ci\]/d')"
@@ -204,13 +211,19 @@ jobs:
         if: ${{ !contains(needs.init.outputs.arg1, 'rebase') && !contains(needs.init.outputs.arg1, 'amend') }}
         env:
           HEAD_REF: ${{ needs.init.outputs.head_ref }}
-        run: git push origin "$HEAD_REF"
+          BOT_TOKEN: ${{ secrets.COMMAND_BOT_PAT }}
+        run: |
+          git remote set-url origin "https://x-access-token:${BOT_TOKEN}@github.com/${{ github.repository }}.git"
+          git push origin "$HEAD_REF"
 
       - name: Force push
         if: ${{ contains(needs.init.outputs.arg1, 'rebase') || contains(needs.init.outputs.arg1, 'amend') }}
         env:
           HEAD_REF: ${{ needs.init.outputs.head_ref }}
-        run: git push --force-with-lease origin "$HEAD_REF"
+          BOT_TOKEN: ${{ secrets.COMMAND_BOT_PAT }}
+        run: |
+          git remote set-url origin "https://x-access-token:${BOT_TOKEN}@github.com/${{ github.repository }}.git"
+          git push --force-with-lease origin "$HEAD_REF"
 
       - name: Add reaction on failure
         uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0

--- a/workflow-templates/command-compile.yml
+++ b/workflow-templates/command-compile.yml
@@ -105,8 +105,7 @@ jobs:
       - name: Checkout ${{ needs.init.outputs.head_ref }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          # Needed to allow force push later
-          persist-credentials: true
+          persist-credentials: false
           token: ${{ secrets.COMMAND_BOT_PAT }}
           fetch-depth: 0
           ref: ${{ needs.init.outputs.head_ref }}
@@ -134,11 +133,13 @@ jobs:
 
       - name: Rebase to ${{ needs.init.outputs.base_ref }}
         if: ${{ contains(needs.init.outputs.arg1, 'rebase') }}
+        env:
+          BASE_REF: ${{ needs.init.outputs.base_ref }}
         run: |
-          git fetch origin '${{ needs.init.outputs.base_ref }}:${{ needs.init.outputs.base_ref }}'
+          git fetch origin "${BASE_REF}:${BASE_REF}"
 
           # Start the rebase
-          git rebase 'origin/${{ needs.init.outputs.base_ref }}' || {
+          git rebase "origin/${BASE_REF}" || {
             # Handle rebase conflicts in a loop
             while [ -d .git/rebase-merge ] || [ -d .git/rebase-apply ]; do
               echo "Handling rebase conflict..."
@@ -146,11 +147,11 @@ jobs:
               # Remove and checkout /dist and /js folders from the base branch
               if [ -d "dist" ]; then
                 rm -rf dist
-                git checkout origin/${{ needs.init.outputs.base_ref }} -- dist/ 2>/dev/null || echo "No dist folder in base branch"
+                git checkout "origin/${BASE_REF}" -- dist/ 2>/dev/null || echo "No dist folder in base branch"
               fi
               if [ -d "js" ]; then
                 rm -rf js
-                git checkout origin/${{ needs.init.outputs.base_ref }} -- js/ 2>/dev/null || echo "No js folder in base branch"
+                git checkout "origin/${BASE_REF}" -- js/ 2>/dev/null || echo "No js folder in base branch"
               fi
 
               # Stage all changes
@@ -182,20 +183,26 @@ jobs:
 
       - name: Commit default
         if: ${{ !contains(needs.init.outputs.arg1, 'fixup') && !contains(needs.init.outputs.arg1, 'amend') }}
+        env:
+          GIT_PATH: ${{ needs.init.outputs.git_path }}
         run: |
-          git add '${{ github.workspace }}${{ needs.init.outputs.git_path }}'
+          git add "${GITHUB_WORKSPACE}${GIT_PATH}"
           git commit --signoff -m 'chore(assets): Recompile assets'
 
       - name: Commit fixup
         if: ${{ contains(needs.init.outputs.arg1, 'fixup') }}
+        env:
+          GIT_PATH: ${{ needs.init.outputs.git_path }}
         run: |
-          git add '${{ github.workspace }}${{ needs.init.outputs.git_path }}'
+          git add "${GITHUB_WORKSPACE}${GIT_PATH}"
           git commit --fixup=HEAD --signoff
 
       - name: Commit amend
         if: ${{ contains(needs.init.outputs.arg1, 'amend') }}
+        env:
+          GIT_PATH: ${{ needs.init.outputs.git_path }}
         run: |
-          git add '${{ github.workspace }}${{ needs.init.outputs.git_path }}'
+          git add "${GITHUB_WORKSPACE}${GIT_PATH}"
           git commit --amend --no-edit --signoff
           # Remove any [skip ci] from the amended commit
           git commit --amend -m "$(git log -1 --format='%B' | sed '/\[skip ci\]/d')"
@@ -204,13 +211,19 @@ jobs:
         if: ${{ !contains(needs.init.outputs.arg1, 'rebase') && !contains(needs.init.outputs.arg1, 'amend') }}
         env:
           HEAD_REF: ${{ needs.init.outputs.head_ref }}
-        run: git push origin "$HEAD_REF"
+          BOT_TOKEN: ${{ secrets.COMMAND_BOT_PAT }}
+        run: |
+          git remote set-url origin "https://x-access-token:${BOT_TOKEN}@github.com/${{ github.repository }}.git"
+          git push origin "$HEAD_REF"
 
       - name: Force push
         if: ${{ contains(needs.init.outputs.arg1, 'rebase') || contains(needs.init.outputs.arg1, 'amend') }}
         env:
           HEAD_REF: ${{ needs.init.outputs.head_ref }}
-        run: git push --force-with-lease origin "$HEAD_REF"
+          BOT_TOKEN: ${{ secrets.COMMAND_BOT_PAT }}
+        run: |
+          git remote set-url origin "https://x-access-token:${BOT_TOKEN}@github.com/${{ github.repository }}.git"
+          git push --force-with-lease origin "$HEAD_REF"
 
       - name: Add reaction on failure
         uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0


### PR DESCRIPTION
Hardens the `/compile` comment-command workflow template.

- Switch checkout to `persist-credentials: false` so the PAT is not in the credential store during `npm ci` / `npm run build`
- Add explicit `git remote set-url` before push steps to supply credentials at push time only
- Replace `${{ }}` interpolation in `run:` blocks with `env:` indirection (defense-in-depth)

Companion PR: nextcloud/server#59464