### PR TITLE
fix: only enable automerge dependencies on on open / reopen

### DIFF
--- a/workflow-templates/dependabot-approve-merge.yml
+++ b/workflow-templates/dependabot-approve-merge.yml
@@ -53,6 +53,6 @@ jobs:
       # Enable GitHub auto merge
       - name: Auto merge
         uses: alexwilson/enable-github-automerge-action@56e3117d1ae1540309dc8f7a9f2825bc3c5f06ff # v2.0.0
-        if: startsWith(steps.branchname.outputs.branch, 'dependabot/')
+        if: startsWith(steps.branchname.outputs.branch, 'dependabot/') && (github.event.pull_request.action == 'opened' || github.event.pull_request.action == 'reopened')
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/workflow-templates/renovate-approve-merge.yml
+++ b/workflow-templates/renovate-approve-merge.yml
@@ -53,6 +53,6 @@ jobs:
       # Enable GitHub auto merge
       - name: Auto merge
         uses: alexwilson/enable-github-automerge-action@56e3117d1ae1540309dc8f7a9f2825bc3c5f06ff # v2.0.0
-        if: startsWith(steps.branchname.outputs.branch, 'renovate/')
+        if: startsWith(steps.branchname.outputs.branch, 'renovate/') && (github.event.pull_request.action == 'opened' || github.event.pull_request.action == 'reopened')
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Only enable the automerge when the PR is opened or reopened, but not if e.g. rebased or pushed. This is needed if the PR is known bad and you try to fix it, but in the meantime its automerged, even if you disabled it.