### PR TITLE
fix(dependabot): only auto-merge minor and patch updates

### DIFF
--- a/workflow-templates/dependabot-approve-merge.yml
+++ b/workflow-templates/dependabot-approve-merge.yml
@@ -44,6 +44,12 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@ffa630c65fa7e0ecfa0625b5ceda64399aea1b36 # v3.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
       # GitHub actions bot approve
       - uses: hmarr/auto-approve-action@f0939ea97e9205ef24d872e76833fa908a770363 # v4.0.0
         if: startsWith(steps.branchname.outputs.branch, 'dependabot/')
@@ -53,6 +59,6 @@ jobs:
       # Enable GitHub auto merge
       - name: Auto merge
         uses: alexwilson/enable-github-automerge-action@56e3117d1ae1540309dc8f7a9f2825bc3c5f06ff # v2.0.0
-        if: startsWith(steps.branchname.outputs.branch, 'dependabot/')
+        if: startsWith(steps.branchname.outputs.branch, 'dependabot/') && (steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor')
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/workflow-templates/dependabot-approve-merge.yml
+++ b/workflow-templates/dependabot-approve-merge.yml
@@ -44,6 +44,12 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@ffa630c65fa7e0ecfa0625b5ceda64399aea1b36 # v3.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
       # GitHub actions bot approve
       - uses: hmarr/auto-approve-action@f0939ea97e9205ef24d872e76833fa908a770363 # v4.0.0
         if: startsWith(steps.branchname.outputs.branch, 'dependabot/')
@@ -53,6 +59,6 @@ jobs:
       # Enable GitHub auto merge
       - name: Auto merge
         uses: alexwilson/enable-github-automerge-action@56e3117d1ae1540309dc8f7a9f2825bc3c5f06ff # 2.0.0
-        if: startsWith(steps.branchname.outputs.branch, 'dependabot/') && (github.event.pull_request.action == 'opened' || github.event.pull_request.action == 'reopened')
+        if: startsWith(steps.branchname.outputs.branch, 'dependabot/') && (github.event.action == 'opened' || github.event.action == 'reopened') && (steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor')
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The risks of breaking your app with unchecked major updates is quite high, so we can approve but the maintainer should at least manually merge the PR for major updates.