### PR TITLE
fix(psalm-phpstan): Remove roave/security-advisories

### DIFF
--- a/workflow-templates/phpstan.yml
+++ b/workflow-templates/phpstan.yml
@@ -52,9 +52,6 @@ jobs:
           composer remove nextcloud/ocp --dev --no-scripts
           composer i
 
-      - name: Check for vulnerable PHP dependencies
-        run: composer require --dev roave/security-advisories:dev-latest
-
       - name: Install nextcloud/ocp
         run: composer require --dev nextcloud/ocp:dev-${{ steps.versions.outputs.branches-max }} --ignore-platform-reqs --with-dependencies
 

--- a/workflow-templates/psalm-matrix.yml
+++ b/workflow-templates/psalm-matrix.yml
@@ -67,9 +67,6 @@ jobs:
           composer remove nextcloud/ocp --dev --no-scripts
           composer i
 
-      - name: Check for vulnerable PHP dependencies
-        run: composer require --dev roave/security-advisories:dev-latest
-
       - name: Install dependencies # zizmor: ignore[template-injection]
         run: composer require --dev 'nextcloud/ocp:${{ matrix.ocp-version }}' --ignore-platform-reqs --with-dependencies
 

--- a/workflow-templates/psalm.yml
+++ b/workflow-templates/psalm.yml
@@ -52,9 +52,6 @@ jobs:
           composer remove nextcloud/ocp --dev --no-scripts
           composer i
 
-      - name: Check for vulnerable PHP dependencies
-        run: composer require --dev roave/security-advisories:dev-latest
-
       - name: Install nextcloud/ocp
         run: composer require --dev nextcloud/ocp:dev-${{ steps.versions.outputs.branches-max }} --ignore-platform-reqs --with-dependencies
 


### PR DESCRIPTION
Following the advice of Sebastian from https://phpunit.expert/articles/the-bouncer-in-the-dependency-resolver.html?ref=mastodon#a-real-world-example
This should no longer be needed as of composer 2.9