### PR TITLE
fix(psalm-matrix): Fix PHP version pick up from matrix job

### DIFF
--- a/workflow-templates/psalm-matrix.yml
+++ b/workflow-templates/psalm-matrix.yml
@@ -22,6 +22,7 @@ jobs:
     runs-on: ubuntu-latest-low
     outputs:
       ocp-matrix: ${{ steps.versions.outputs.ocp-matrix }}
+      php-min: ${{ steps.versions.outputs.php-min }}
     steps:
       - name: Checkout app
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -50,10 +51,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up php${{ matrix.php-min }}
+      - name: Set up php${{ needs.matrix.outputs.php-min }}
         uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2.37.0
         with:
-          php-version: ${{ matrix.php-min }}
+          php-version: ${{ needs.matrix.outputs.php-min }}
           extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite
           coverage: none
           ini-file: development


### PR DESCRIPTION
Note how there is no version number after `php` in the setup title. It just worked so far as all apps using matrix were stretching over all php versions we have installed on the runner images

Before | After
---|---
<img width="1076" height="502" alt="Bildschirmfoto vom 2026-05-12 12-05-51" src="https://github.com/user-attachments/assets/d3220e03-adf1-42a1-b938-345764f6002c" /> | <img width="1076" height="502" alt="Bildschirmfoto vom 2026-05-12 12-05-36" src="https://github.com/user-attachments/assets/631c4507-4aca-4b89-88a4-a2bee62ef92c" />
