### PR TITLE
fix: correctly use `github.event.action` to fetch the type of event

### DIFF
--- a/workflow-templates/renovate-approve-merge.yml
+++ b/workflow-templates/renovate-approve-merge.yml
@@ -53,6 +53,6 @@ jobs:
       # Enable GitHub auto merge
       - name: Auto merge
         uses: alexwilson/enable-github-automerge-action@56e3117d1ae1540309dc8f7a9f2825bc3c5f06ff # 2.0.0
-        if: startsWith(steps.branchname.outputs.branch, 'renovate/') && (github.event.pull_request.action == 'opened' || github.event.pull_request.action == 'reopened')
+        if: startsWith(steps.branchname.outputs.branch, 'renovate/') && (github.event.action == 'opened' || github.event.action == 'reopened')
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
`github.event.pull_request` is the pull request object not the event object, so `.action` always resolves to null and breaks auto-merge.