### PR TITLE
fix: use one-line `gh` script instead of unmaintained action

### DIFF
--- a/workflow-templates/dependabot-approve-merge.yml
+++ b/workflow-templates/dependabot-approve-merge.yml
@@ -27,7 +27,7 @@ jobs:
     if: github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest-low
     permissions:
-      # for hmarr/auto-approve-action to approve PRs
+      # for auto-approve step to work
       pull-requests: write
       # for alexwilson/enable-github-automerge-action to approve PRs
       contents: write
@@ -50,11 +50,12 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      # GitHub actions bot approve
-      - uses: hmarr/auto-approve-action@f0939ea97e9205ef24d872e76833fa908a770363 # v4.0.0
+      - name: GitHub actions bot approve
         if: startsWith(steps.branchname.outputs.branch, 'dependabot/')
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Enable GitHub auto merge
       - name: Auto merge

--- a/workflow-templates/renovate-approve-merge.yml
+++ b/workflow-templates/renovate-approve-merge.yml
@@ -27,7 +27,7 @@ jobs:
     if: github.event.pull_request.user.login == 'renovate[bot]'
     runs-on: ubuntu-latest
     permissions:
-      # for hmarr/auto-approve-action to approve PRs
+      # for auto-approve step to work
       pull-requests: write
       # for alexwilson/enable-github-automerge-action to approve PRs
       contents: write
@@ -44,11 +44,12 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      # GitHub actions bot approve
-      - uses: hmarr/auto-approve-action@f0939ea97e9205ef24d872e76833fa908a770363 # v4.0.0
+      - name: GitHub actions bot approve
         if: startsWith(steps.branchname.outputs.branch, 'renovate/')
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Enable GitHub auto merge
       - name: Auto merge

--- a/workflow-templates/update-nextcloud-ocp-approve-merge.yml
+++ b/workflow-templates/update-nextcloud-ocp-approve-merge.yml
@@ -27,7 +27,7 @@ jobs:
     if: github.actor == 'nextcloud-command'
     runs-on: ubuntu-latest-low
     permissions:
-      # for hmarr/auto-approve-action to approve PRs
+      # for auto-approve-action to approve PRs
       pull-requests: write
       # for alexwilson/enable-github-automerge-action to approve PRs
       contents: write
@@ -44,11 +44,12 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      # GitHub actions bot approve
-      - uses: hmarr/auto-approve-action@b40d6c9ed2fa10c9a2749eca7eb004418a705501 # v2
+      - name: GitHub actions bot approve
         if: startsWith(steps.branchname.outputs.branch, 'automated/noid/') && endsWith(steps.branchname.outputs.branch, 'update-nextcloud-ocp')
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Enable GitHub auto merge
       - name: Auto merge


### PR DESCRIPTION
The auto-approve action is unmaintained currently and still uses Node 20 which is deprecated by GitHub and will be removed soon. Auto-approve can be replaced with a 1-line `gh` script.