### PR TITLE
fix(dependabot): control auto-merge with env variables

### DIFF
--- a/workflow-templates/dependabot-approve-merge.yml
+++ b/workflow-templates/dependabot-approve-merge.yml
@@ -26,6 +26,11 @@ jobs:
   auto-approve-merge:
     if: github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest-low
+    env:
+      # env variable for maintainers: 'true' allows to auto-merge 1.0.2 -> 2.0.0
+      ALLOW_MAJOR: false
+      # env variable for maintainers: 'true' allows to auto-merge 1.0.2 -> 1.1.0
+      ALLOW_MINOR: true
       # env variable for maintainers: RegExp string to ignore some dependencies from auto-approve and auto-merge
       IGNORE_PATTERN: ''
     permissions:
@@ -88,7 +93,8 @@ jobs:
           && (github.event.action == 'opened' || github.event.action == 'reopened')
           && (
             steps.metadata.outputs.update-type == 'version-update:semver-patch'
-            || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+            || (fromJSON(env.ALLOW_MINOR) && steps.metadata.outputs.update-type == 'version-update:semver-minor')
+            || (fromJSON(env.ALLOW_MAJOR) && steps.metadata.outputs.update-type == 'version-update:semver-major')
           )
           }}
         with:

--- a/workflow-templates/dependabot-approve-merge.yml
+++ b/workflow-templates/dependabot-approve-merge.yml
@@ -46,12 +46,16 @@ jobs:
 
       - name: Dependabot metadata
         id: metadata
+        if: startsWith(steps.branchname.outputs.branch, 'dependabot/')
         uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: GitHub actions bot approve
-        if: startsWith(steps.branchname.outputs.branch, 'dependabot/')
+        id: auto_approve
+        if: ${{
+          startsWith(steps.branchname.outputs.branch, 'dependabot/')
+          }}
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
@@ -60,6 +64,13 @@ jobs:
       # Enable GitHub auto merge
       - name: Auto merge
         uses: alexwilson/enable-github-automerge-action@2c32e18a76e0726ffe7a573bfff2d42a20885126 # 3.0.0
-        if: startsWith(steps.branchname.outputs.branch, 'dependabot/') && (github.event.action == 'opened' || github.event.action == 'reopened') && (steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor')
+        if: ${{
+          startsWith(steps.branchname.outputs.branch, 'dependabot/')
+          && (github.event.action == 'opened' || github.event.action == 'reopened')
+          && (
+            steps.metadata.outputs.update-type == 'version-update:semver-patch'
+            || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+          )
+          }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/workflow-templates/dependabot-approve-merge.yml
+++ b/workflow-templates/dependabot-approve-merge.yml
@@ -26,6 +26,8 @@ jobs:
   auto-approve-merge:
     if: github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest-low
+      # env variable for maintainers: RegExp string to ignore some dependencies from auto-approve and auto-merge
+      IGNORE_PATTERN: ''
     permissions:
       # for auto-approve step to work
       pull-requests: write
@@ -51,10 +53,26 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Check for ignored dependencies in the PR
+        id: validate
+        if: startsWith(steps.branchname.outputs.branch, 'dependabot/')
+        env:
+          IGNORE_PATTERN: ${{ env.IGNORE_PATTERN }}
+          DEPENDENCY_NAMES: ${{ steps.metadata.outputs.dependency-names }}
+        run: |
+          if [[ -z ${IGNORE_PATTERN} ]]; then
+              echo "ignore=false" >> "$GITHUB_OUTPUT"
+          elif [[ -z ${DEPENDENCY_NAMES} ]]; then
+              echo "ignore=false" >> "$GITHUB_OUTPUT"
+          elif [[ ${DEPENDENCY_NAMES} =~ ${IGNORE_PATTERN} ]]; then
+              echo "ignore=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: GitHub actions bot approve
         id: auto_approve
         if: ${{
           startsWith(steps.branchname.outputs.branch, 'dependabot/')
+          && steps.validate.outputs.ignore != 'true'
           }}
         run: gh pr review --approve "$PR_URL"
         env:
@@ -66,6 +84,7 @@ jobs:
         uses: alexwilson/enable-github-automerge-action@2c32e18a76e0726ffe7a573bfff2d42a20885126 # 3.0.0
         if: ${{
           startsWith(steps.branchname.outputs.branch, 'dependabot/')
+          && steps.auto_approve.conclusion == 'success'
           && (github.event.action == 'opened' || github.event.action == 'reopened')
           && (
             steps.metadata.outputs.update-type == 'version-update:semver-patch'


### PR DESCRIPTION
Based on:
- #706

Copied from:
- https://github.com/nextcloud/spreed/pull/17401
- https://github.com/nextcloud/spreed/pull/17443

Enhancements: ENV variables allow to patch a single line in project to adjust workflow for needs of devs
  - `ALLOW_MAJOR: false` // by default never auto-merge major bumps 1.0.2 -> 2.0.0
  - `ALLOW_MINOR: true` // by default auto-merge minor bumps 1.0.2 -> 1.1.0
  - `IGNORE_PATTERN: ''` // by default all allowed; RegExp string like `'(webrtc-adapter|\@nextcloud\/vue)'` will block libraries that match pattern `webrtc-adapter` or `@nextcloud/vue`

Changes: `steps.auto_approve.conclusion == 'success'` condition - do not auto-merge if wasn't auto-approved