### PR TITLE
fix(lint-php): only run linter on php file changes

### DIFF
--- a/workflow-templates/lint-php.yml
+++ b/workflow-templates/lint-php.yml
@@ -18,8 +18,29 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest-low
+    permissions:
+      contents: read
+      pull-requests: read
+
+    outputs:
+      php: ${{ steps.changes.outputs.php }}
+
+    steps:
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: changes
+        continue-on-error: true
+        with:
+          filters: |
+            php:
+              - '*.php'
+              - '**/*.php'
+
   matrix:
     runs-on: ubuntu-latest-low
+    needs: changes
+    if: needs.changes.outputs.php != 'false'
     outputs:
       php-min: ${{ steps.versions.outputs.php-min }}
       php-max: ${{ steps.versions.outputs.php-max }}
@@ -35,7 +56,8 @@ jobs:
 
   php-lint:
     runs-on: ubuntu-latest
-    needs: matrix
+    needs: [changes, matrix]
+    if: needs.changes.outputs.php != 'false'
     strategy:
       matrix:
         php-versions: ['${{ needs.matrix.outputs.php-min }}', '${{ needs.matrix.outputs.php-max }}']
@@ -65,7 +87,7 @@ jobs:
     permissions:
       contents: none
     runs-on: ubuntu-latest-low
-    needs: php-lint
+    needs: [changes, php-lint]
 
     if: always()
 


### PR DESCRIPTION
### Summary
- added logic to check if a php file was changed, to prevent workflow from running when no php changes have been made