### PR TITLE
fix: AI policy performance

### DIFF
--- a/.github/workflows/ai-policy.yml
+++ b/.github/workflows/ai-policy.yml
@@ -27,23 +27,16 @@ concurrency:
 
 jobs:
   check-ai-trailers:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-low
     steps:
-      - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-
       - name: Collect PR commit messages
         id: collect
         env:
-          BASE_REF: ${{ github.base_ref }}
+          GH_TOKEN: ${{ github.token }}
+          COMMITS_URL: ${{ github.event.pull_request.commits_url }}
         run: |
           set -euo pipefail
-          git fetch origin "${BASE_REF}"
-          MERGE_BASE=$(git merge-base "origin/${BASE_REF}" HEAD)
-          git log --format="%B" "${MERGE_BASE}..HEAD" > /tmp/pr_commits.txt
+          gh api ${COMMITS_URL} | jq -r '.[] | .commit.message' > /tmp/pr_commits.txt
           echo "--- PR commit messages ---"
           cat /tmp/pr_commits.txt
           echo "--------------------------"
@@ -83,10 +76,10 @@ jobs:
         run: |
           set -euo pipefail
           AI_ASSISTED=false
-          if grep -qiE '^(AI-assistant|Assisted-by):' /tmp/pr_commits.txt; then
+          if grep -qiE '^(AI-assistant|Assisted-by|AI-Assisted-By):' /tmp/pr_commits.txt; then
             AI_ASSISTED=true
-            echo "Found AI-assistant/Assisted-by trailer(s):"
-            grep -iE '^(AI-assistant|Assisted-by):' /tmp/pr_commits.txt
+            echo "Found AI-assistant/Assisted-by/AI-Assisted-By trailer(s):"
+            grep -iE '^(AI-assistant|Assisted-by|AI-Assisted-By):' /tmp/pr_commits.txt
           fi
           echo "ai_assisted=${AI_ASSISTED}" >> "$GITHUB_OUTPUT"
 

--- a/workflow-templates/ai-policy.yml
+++ b/workflow-templates/ai-policy.yml
@@ -76,10 +76,10 @@ jobs:
         run: |
           set -euo pipefail
           AI_ASSISTED=false
-          if grep -qiE '^(AI-assistant|Assisted-by):' /tmp/pr_commits.txt; then
+          if grep -qiE '^(AI-assistant|Assisted-by|AI-Assisted-By):' /tmp/pr_commits.txt; then
             AI_ASSISTED=true
-            echo "Found AI-assistant/Assisted-by trailer(s):"
-            grep -iE '^(AI-assistant|Assisted-by):' /tmp/pr_commits.txt
+            echo "Found AI-assistant/Assisted-by/AI-Assisted-By trailer(s):"
+            grep -iE '^(AI-assistant|Assisted-by|AI-Assisted-By):' /tmp/pr_commits.txt
           fi
           echo "ai_assisted=${AI_ASSISTED}" >> "$GITHUB_OUTPUT"
 

--- a/workflow-templates/ai-policy.yml
+++ b/workflow-templates/ai-policy.yml
@@ -27,23 +27,16 @@ concurrency:
 
 jobs:
   check-ai-trailers:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-low
     steps:
-      - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-
       - name: Collect PR commit messages
         id: collect
         env:
-          BASE_REF: ${{ github.base_ref }}
+          GH_TOKEN: ${{ github.token }}
+          COMMITS_URL: ${{ github.event.pull_request.commits_url }}
         run: |
           set -euo pipefail
-          git fetch origin "${BASE_REF}"
-          MERGE_BASE=$(git merge-base "origin/${BASE_REF}" HEAD)
-          git log --format="%B" "${MERGE_BASE}..HEAD" > /tmp/pr_commits.txt
+          gh api ${COMMITS_URL} | jq -r '.[] | .commit.message' > /tmp/pr_commits.txt
           echo "--- PR commit messages ---"
           cat /tmp/pr_commits.txt
           echo "--------------------------"


### PR DESCRIPTION
Current we fetch the complete repo (fetch-depth=0 -> full clone), while we only care about the commit messages of the current PR. For that we can also use the API, which is much faster and does not require a clone at all.

Example run before: https://github.com/nextcloud/server/actions/runs/27487016095/job/81245050374
Example run after: https://github.com/nextcloud/server/actions/runs/27496027145/job/81270136085 (https://github.com/nextcloud/server/pull/61280)

Additionally also checks for "AI-Assisted-By", that I've seen quite a bit.

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
