### PR TITLE
fix(lint): PHP lint is instant in PHP 8.3+ and quick in others for apps

### DIFF
--- a/workflow-templates/lint-php.yml
+++ b/workflow-templates/lint-php.yml
@@ -34,7 +34,7 @@ jobs:
         uses: icewind1991/nextcloud-version-matrix@8a7bac6300b2f0f3100088b297995a229558ddba # v1.3.2
 
   php-lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-low
     needs: matrix
     strategy:
       matrix:


### PR DESCRIPTION

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
