### PR TITLE
feat: Only checkout appinfo/ for xml lint

### DIFF
--- a/workflow-templates/lint-info-xml.yml
+++ b/workflow-templates/lint-info-xml.yml
@@ -27,6 +27,8 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+          sparse-checkout: |
+            appinfo/
 
       - name: Download schema
         run: wget https://raw.githubusercontent.com/nextcloud/appstore/master/nextcloudappstore/api/v1/release/info.xsd


### PR DESCRIPTION
Tiny tweak to only fetch what we need for linting the info.xml

Sample run at: https://github.com/nextcloud/serverinfo/actions/runs/28470416125/job/84381233894?pr=1037 for https://github.com/nextcloud/serverinfo/pull/1037 