### PR TITLE
ci: Fall back to github.token when COMMAND_BOT_PAT is unavailable

### DIFF
--- a/.github/workflows/ai-policy.yml
+++ b/.github/workflows/ai-policy.yml
@@ -32,7 +32,9 @@ jobs:
       - name: Collect PR commit messages
         id: collect
         env:
-          GH_TOKEN: ${{ secrets.COMMAND_BOT_PAT }}
+          # Fall back to the default token when the PAT is unavailable
+          # (e.g. Dependabot- or fork-triggered runs don't receive Actions secrets)
+          GH_TOKEN: ${{ secrets.COMMAND_BOT_PAT || github.token }}
           COMMITS_URL: ${{ github.event.pull_request.commits_url }}
         run: |
           set -euo pipefail
@@ -125,7 +127,9 @@ jobs:
       - name: Create 'AI assisted' label if absent
         if: steps.ai_trailers.outputs.ai_assisted == 'true' || steps.agent_signoff.outputs.agent_signoff == 'true' || steps.co_authored.outputs.co_authored == 'true'
         env:
-          GH_TOKEN: ${{ secrets.COMMAND_BOT_PAT }}
+          # Fall back to the default token when the PAT is unavailable
+          # (e.g. Dependabot- or fork-triggered runs don't receive Actions secrets)
+          GH_TOKEN: ${{ secrets.COMMAND_BOT_PAT || github.token }}
         run: |
           gh api "repos/${{ github.repository }}/labels" \
             --method POST \
@@ -137,7 +141,9 @@ jobs:
       - name: Label PR as AI assisted
         if: steps.ai_trailers.outputs.ai_assisted == 'true' || steps.agent_signoff.outputs.agent_signoff == 'true' || steps.co_authored.outputs.co_authored == 'true'
         env:
-          GH_TOKEN: ${{ secrets.COMMAND_BOT_PAT }}
+          # Fall back to the default token when the PAT is unavailable
+          # (e.g. Dependabot- or fork-triggered runs don't receive Actions secrets)
+          GH_TOKEN: ${{ secrets.COMMAND_BOT_PAT || github.token }}
         run: |
           gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels" \
             --method POST \

--- a/workflow-templates/ai-policy.yml
+++ b/workflow-templates/ai-policy.yml
@@ -32,7 +32,9 @@ jobs:
       - name: Collect PR commit messages
         id: collect
         env:
-          GH_TOKEN: ${{ secrets.COMMAND_BOT_PAT }}
+          # Fall back to the default token when the PAT is unavailable
+          # (e.g. Dependabot- or fork-triggered runs don't receive Actions secrets)
+          GH_TOKEN: ${{ secrets.COMMAND_BOT_PAT || github.token }}
           COMMITS_URL: ${{ github.event.pull_request.commits_url }}
         run: |
           set -euo pipefail
@@ -125,7 +127,9 @@ jobs:
       - name: Create 'AI assisted' label if absent
         if: steps.ai_trailers.outputs.ai_assisted == 'true' || steps.agent_signoff.outputs.agent_signoff == 'true' || steps.co_authored.outputs.co_authored == 'true'
         env:
-          GH_TOKEN: ${{ secrets.COMMAND_BOT_PAT }}
+          # Fall back to the default token when the PAT is unavailable
+          # (e.g. Dependabot- or fork-triggered runs don't receive Actions secrets)
+          GH_TOKEN: ${{ secrets.COMMAND_BOT_PAT || github.token }}
         run: |
           gh api "repos/${{ github.repository }}/labels" \
             --method POST \
@@ -137,7 +141,9 @@ jobs:
       - name: Label PR as AI assisted
         if: steps.ai_trailers.outputs.ai_assisted == 'true' || steps.agent_signoff.outputs.agent_signoff == 'true' || steps.co_authored.outputs.co_authored == 'true'
         env:
-          GH_TOKEN: ${{ secrets.COMMAND_BOT_PAT }}
+          # Fall back to the default token when the PAT is unavailable
+          # (e.g. Dependabot- or fork-triggered runs don't receive Actions secrets)
+          GH_TOKEN: ${{ secrets.COMMAND_BOT_PAT || github.token }}
         run: |
           gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels" \
             --method POST \


### PR DESCRIPTION
## Summary

Follow-up to #756, which switched `GH_TOKEN` to `secrets.COMMAND_BOT_PAT`. Dependabot- and fork-triggered `pull_request` runs don't receive repository/organization Actions secrets, so the PAT resolves to an empty string and `gh` exits with code 4 on the very first step (see the failing runs on #757 and #758).

This adds a fallback so those runs use the default workflow token instead:

```yaml
GH_TOKEN: ${{ secrets.COMMAND_BOT_PAT || github.token }}
```

- The **collect step** only reads commit messages, which the default read-only token can always do — this unblocks Dependabot and fork PRs.
- The **label steps** still prefer the PAT when available; they only fire when AI trailers are detected, which won't happen on Dependabot PRs.

Applied to both the live workflow and the org template.

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)