### PR TITLE
fix(rector): Don't drop nextcloud/ocp

### DIFF
--- a/workflow-templates/rector-apply.yml
+++ b/workflow-templates/rector-apply.yml
@@ -45,10 +45,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Remove nextcloud/ocp
-        run: |
-          composer remove nextcloud/ocp --dev --no-scripts
-
       - name: Install composer dependencies
         uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
 


### PR DESCRIPTION
- Otherwise creates a diff and makes psalm no longer execute locally: https://github.com/nextcloud/spreed/pull/18745/changes
- In case this is required for some apps (I could see apps without composer bin or multi-branch having issues with the version conflicting from rector?) we need to adjust the `peter-evans/create-pull-request` and only commit lib/ and tests/ or something alike

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
