### PR TITLE
Address recurring AI review findings in policy and agent snippets

### DIFF
--- a/AGENT_MD_SNIPPETS.md
+++ b/AGENT_MD_SNIPPETS.md
@@ -16,6 +16,14 @@ All contributions generated or assisted by this agent must fully comply with:
 - Ensure every pull request includes a disclosure of AI tool use in the PR description.
 - Produce focused, scoped pull requests that address exactly one concern. Do not touch unrelated files or introduce incidental refactors.
 - Verify all dependencies against actual package registries before suggesting them. Do not use hallucinated or unverified package names.
+- Write code comments that document the code, never the process that produced it:
+  - Comments describe what the code does - method signatures, behavior, and constraints the code itself cannot express (e.g. a non-obvious invariant or workaround).
+  - Never add comments that document progress, decisions, or changes (e.g. "changed X to Y", "as requested", "this fixes ...", "previously this did ..."). That belongs in the commit message or PR discussion; in the code it goes stale and becomes misleading.
+  - Do not narrate self-explanatory code. If the code is readable without a comment, omit the comment.
+  - Keep comments brief - short and simple, matching the comment density of the surrounding code.
+- Reuse existing helper functions and utilities instead of re-implementing their logic inline. When fixing a flawed pattern, fix every occurrence of it across the changed code, not only the instance that was pointed out.
+- Run permission and access-control checks before the operation they guard, never after it and never only in the UI layer.
+- When adding or changing user-facing functionality, wire it up in every context where the affected component is used - the default authenticated view, public share pages, and embedded contexts such as the Smart Picker and reference widgets. When emitting new events, verify that every consumer of the component subscribes to and handles them.
 - Explicitly inform the contributor when any action they are about to take, or have taken, would violate the AI Contribution Policy or the Contribution Guidelines. Do not silently proceed. State which rule is at risk and what the contributor should do instead.
 - Warn the contributor if a pull request is growing too large. A PR approaching several thousand lines of changed code is a signal that it should be split into smaller, focused PRs. Suggest a logical split before the PR is opened, not after.
 - Recommend opening a ticket for discussion before starting implementation whenever a feature or change is sufficiently complex - for example when it touches multiple subsystems, requires architectural decisions, or the right approach is not yet clear. A ticket allows maintainers and the contributor to align on direction before code is written, avoiding wasted effort on a PR that may be rejected or require fundamental rework.
@@ -27,4 +35,4 @@ All contributions generated or assisted by this agent must fully comply with:
 - Generate or submit security reports without independent human verification. Report verified vulnerabilities via [HackerOne](https://hackerone.com/nextcloud), not as GitHub issues.
 - Write PR descriptions, review comments, or issue reports on behalf of the contributor. These must be in the contributor's own words.
 - Fully automate the resolution of issues labeled [`good first issue`](https://github.com/issues?q=org%3Anextcloud+label%3A%22good+first+issue%22) or similar beginner-friendly labels.
-- Submit code that has not been reviewed and cleaned up by the contributor. Dead code, redundant logic, excessive comments, and unrelated changes must be removed before submission.
+- Submit code that has not been reviewed and cleaned up by the contributor. Dead code, redundant logic, excessive comments, malformed or garbled characters (e.g. `�` replacement characters), and unrelated changes must be removed before submission.

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -66,11 +66,15 @@ The applicable test has three parts: the AI tool's terms must permit open-source
 
 ### Code Quality and Cleanup
 
-AI output must be cleaned before submission. Dead code, redundant logic, excessive comments, inconsistent style, unused variables, structural drift, and unrelated file changes must all be removed. Submitting large AI code blobs without meaningful oversight - sometimes called "vibe coding" or "prompt dumping" - is prohibited.
+AI output must be cleaned before submission. Dead code, redundant logic, excessive comments, inconsistent style, unused variables, malformed or garbled characters, structural drift, and unrelated file changes must all be removed. Submitting large AI code blobs without meaningful oversight - sometimes called "vibe coding" or "prompt dumping" - is prohibited.
+
+Code comments must document the code itself - behavior, signatures, and constraints the code cannot express - never the process that produced it. Progress notes, decision records, and change descriptions ("changed X to Y", "as requested", "this fixes ...") belong in the commit message or PR discussion; in code they go stale and become misleading. Comments must stay brief and match the comment density of the surrounding code, and self-explanatory code needs no comment at all.
+
+Duplicated logic is a further common sign of unreviewed AI output: existing helpers and utilities must be reused instead of re-implemented, and when a flawed pattern is corrected, every occurrence of it must be fixed - not only the one a reviewer happened to point out.
 
 Signs of a disallowed submission include: large unreviewed AI blobs; obvious mechanical mistakes a human would fix in minutes; code that has clearly never been executed; and pull requests that shift debugging and cleanup work onto maintainers rather than the contributor. As required by the [Contribution Guidelines](CONTRIBUTING.md), all changed and added code must be unit tested - AI-generated code is not exempt from this requirement.
 
-New features must be tested on a live Nextcloud instance by the contributor before submission. Providing test instructions for an AI agent to execute is not a substitute for human testing.
+New features must be tested on a live Nextcloud instance by the contributor before submission, and in every context in which they are reachable - not only the default authenticated view, but also public share links, embedded contexts such as the Smart Picker and reference widgets, and other entry points the app supports. AI-generated changes frequently work in the primary view while silently failing in secondary ones. Providing test instructions for an AI agent to execute is not a substitute for human testing.
 
 ---
 


### PR DESCRIPTION
Incorporate the code comment conventions from nextcloud/notes#1982 and generalize recurring review feedback on AI-assisted PRs:

- Code comments must document the code, never the process that produced it; keep them brief and matching surrounding density
- Reuse existing helpers instead of duplicating logic, and fix every occurrence of a flawed pattern
- Run permission/access-control checks before the guarded operation
- Wire up and test features in every reachable context (public shares, Smart Picker/reference widgets), not only the default authenticated view
- Remove malformed/garbled characters from generated output

Assisted-by: Claude Code:claude-fable-5

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
