### PR TITLE
fix(command-compile): clean up existing css compiled assets before commit

### DIFF
--- a/workflow-templates/command-compile.yml
+++ b/workflow-templates/command-compile.yml
@@ -144,7 +144,7 @@ jobs:
             while [ -d .git/rebase-merge ] || [ -d .git/rebase-apply ]; do
               echo "Handling rebase conflict..."
 
-              # Remove and checkout /dist and /js folders from the base branch
+              # Remove and checkout /dist, /js, /css folders from the base branch
               if [ -d "dist" ]; then
                 rm -rf dist
                 git checkout "origin/${BASE_REF}" -- dist/ 2>/dev/null || echo "No dist folder in base branch"
@@ -152,6 +152,10 @@ jobs:
               if [ -d "js" ]; then
                 rm -rf js
                 git checkout "origin/${BASE_REF}" -- js/ 2>/dev/null || echo "No js folder in base branch"
+              fi
+              if [ -d "css" ]; then
+                rm -rf css
+                git checkout "origin/${BASE_REF}" -- css/ 2>/dev/null || echo "No css folder in base branch"
               fi
 
               # Stage all changes


### PR DESCRIPTION
Was either skipped or not considered?

Result of 'rm -rf css && npm run build' on logreader repo:
<img width="700" height="983" alt="image" src="https://github.com/user-attachments/assets/74ecd38d-af9d-44fb-b4ae-7c5170592bf3" />


## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
