### PR TITLE
fix: Combine changes and matrix jobs

### DIFF
--- a/workflow-templates/phpunit-mariadb.yml
+++ b/workflow-templates/phpunit-mariadb.yml
@@ -18,29 +18,16 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  matrix:
-    runs-on: ubuntu-latest-low
-    outputs:
-      php-version: ${{ steps.versions.outputs.php-available-list }}
-      server-max: ${{ steps.versions.outputs.branches-max-list }}
-    steps:
-      - name: Checkout app
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      - name: Get version matrix
-        id: versions
-        uses: nextcloud-libraries/nextcloud-version-matrix@cd0211ffcef1065e2020cd579e4843b8746e7a58 # v1.3.3
-
-  changes:
+  changes-and-matrix:
     runs-on: ubuntu-latest-low
     permissions:
       contents: read
       pull-requests: read
 
     outputs:
-      src: ${{ steps.changes.outputs.src}}
+      src: ${{ steps.changes.outputs.src }}
+      php-version: ${{ steps.versions.outputs.php-available-list }}
+      server-max: ${{ steps.versions.outputs.branches-max-list }}
 
     steps:
       - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
@@ -60,17 +47,28 @@ jobs:
               - 'composer.json'
               - 'composer.lock'
 
+      - name: Checkout app
+        if: steps.changes.outputs.src != 'false'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Get version matrix
+        if: steps.changes.outputs.src != 'false'
+        id: versions
+        uses: nextcloud-libraries/nextcloud-version-matrix@cd0211ffcef1065e2020cd579e4843b8746e7a58 # v1.3.3
+
   phpunit-mariadb:
     runs-on: ubuntu-latest
 
-    needs: [changes, matrix]
-    if: needs.changes.outputs.src != 'false'
+    needs: changes-and-matrix
+    if: needs.changes-and-matrix.outputs.src != 'false'
 
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ${{ fromJson(needs.matrix.outputs.php-version) }}
-        server-versions: ${{ fromJson(needs.matrix.outputs.server-max) }}
+        php-versions: ${{ fromJson(needs.changes-and-matrix.outputs.php-version) }}
+        server-versions: ${{ fromJson(needs.changes-and-matrix.outputs.server-max) }}
         mariadb-versions: ['10.6', '11.4']
 
     name: MariaDB ${{ matrix.mariadb-versions }} PHP ${{ matrix.php-versions }} Nextcloud ${{ matrix.server-versions }}
@@ -196,7 +194,7 @@ jobs:
     permissions:
       contents: none
     runs-on: ubuntu-latest-low
-    needs: [changes, phpunit-mariadb]
+    needs: [changes-and-matrix, phpunit-mariadb]
 
     if: always()
 
@@ -204,4 +202,4 @@ jobs:
 
     steps:
       - name: Summary status
-        run: if ${{ needs.changes.outputs.src != 'false' && needs.phpunit-mariadb.result != 'success' }}; then exit 1; fi
+        run: if ${{ needs.changes-and-matrix.outputs.src != 'false' && needs.phpunit-mariadb.result != 'success' }}; then exit 1; fi

--- a/workflow-templates/phpunit-mysql.yml
+++ b/workflow-templates/phpunit-mysql.yml
@@ -18,30 +18,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  matrix:
-    runs-on: ubuntu-latest-low
-    outputs:
-      matrix: ${{ steps.versions.outputs.sparse-matrix }}
-    steps:
-      - name: Checkout app
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      - name: Get version matrix
-        id: versions
-        uses: nextcloud-libraries/nextcloud-version-matrix@cd0211ffcef1065e2020cd579e4843b8746e7a58 # v1.3.3
-        with:
-          matrix: '{"mysql-versions": ["8.4"]}'
-
-  changes:
+  changes-and-matrix:
     runs-on: ubuntu-latest-low
     permissions:
       contents: read
       pull-requests: read
 
     outputs:
-      src: ${{ steps.changes.outputs.src}}
+      src: ${{ steps.changes.outputs.src }}
+      matrix: ${{ steps.versions.outputs.sparse-matrix }}
 
     steps:
       - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
@@ -61,15 +46,28 @@ jobs:
               - 'composer.json'
               - 'composer.lock'
 
+      - name: Checkout app
+        if: steps.changes.outputs.src != 'false'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Get version matrix
+        if: steps.changes.outputs.src != 'false'
+        id: versions
+        uses: nextcloud-libraries/nextcloud-version-matrix@cd0211ffcef1065e2020cd579e4843b8746e7a58 # v1.3.3
+        with:
+          matrix: '{"mysql-versions": ["8.4"]}'
+
   phpunit-mysql:
     runs-on: ubuntu-latest
 
-    needs: [changes, matrix]
-    if: needs.changes.outputs.src != 'false'
+    needs: changes-and-matrix
+    if: needs.changes-and-matrix.outputs.src != 'false'
 
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(needs.matrix.outputs.matrix) }}
+      matrix: ${{ fromJson(needs.changes-and-matrix.outputs.matrix) }}
 
     name: MySQL ${{ matrix.mysql-versions }} PHP ${{ matrix.php-versions }} Nextcloud ${{ matrix.server-versions }}
 
@@ -194,7 +192,7 @@ jobs:
     permissions:
       contents: none
     runs-on: ubuntu-latest-low
-    needs: [changes, phpunit-mysql]
+    needs: [changes-and-matrix, phpunit-mysql]
 
     if: always()
 
@@ -202,4 +200,4 @@ jobs:
 
     steps:
       - name: Summary status
-        run: if ${{ needs.changes.outputs.src != 'false' && needs.phpunit-mysql.result != 'success' }}; then exit 1; fi
+        run: if ${{ needs.changes-and-matrix.outputs.src != 'false' && needs.phpunit-mysql.result != 'success' }}; then exit 1; fi

--- a/workflow-templates/phpunit-oci.yml
+++ b/workflow-templates/phpunit-oci.yml
@@ -18,22 +18,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  matrix:
-    runs-on: ubuntu-latest-low
-    outputs:
-      php-version: ${{ steps.versions.outputs.php-available-list }}
-      server-max: ${{ steps.versions.outputs.branches-max-list }}
-    steps:
-      - name: Checkout app
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      - name: Get version matrix
-        id: versions
-        uses: nextcloud-libraries/nextcloud-version-matrix@cd0211ffcef1065e2020cd579e4843b8746e7a58 # v1.3.3
-
-  changes:
+  changes-and-matrix:
     runs-on: ubuntu-latest-low
     permissions:
       contents: read
@@ -41,6 +26,8 @@ jobs:
 
     outputs:
       src: ${{ steps.changes.outputs.src }}
+      php-version: ${{ steps.versions.outputs.php-available-list }}
+      server-max: ${{ steps.versions.outputs.branches-max-list }}
 
     steps:
       - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
@@ -60,17 +47,28 @@ jobs:
               - 'composer.json'
               - 'composer.lock'
 
+      - name: Checkout app
+        if: steps.changes.outputs.src != 'false'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Get version matrix
+        if: steps.changes.outputs.src != 'false'
+        id: versions
+        uses: nextcloud-libraries/nextcloud-version-matrix@cd0211ffcef1065e2020cd579e4843b8746e7a58 # v1.3.3
+
   phpunit-oci:
     runs-on: ubuntu-latest
 
-    needs: [changes, matrix]
-    if: needs.changes.outputs.src != 'false'
+    needs: changes-and-matrix
+    if: needs.changes-and-matrix.outputs.src != 'false'
 
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ${{ fromJson(needs.matrix.outputs.php-version) }}
-        server-versions: ${{ fromJson(needs.matrix.outputs.server-max) }}
+        php-versions: ${{ fromJson(needs.changes-and-matrix.outputs.php-version) }}
+        server-versions: ${{ fromJson(needs.changes-and-matrix.outputs.server-max) }}
         oci-versions: ['18', '21', '23']
 
     name: OCI ${{ matrix.oci-versions }} PHP ${{ matrix.php-versions }} Nextcloud ${{ matrix.server-versions }}
@@ -201,7 +199,7 @@ jobs:
     permissions:
       contents: none
     runs-on: ubuntu-latest-low
-    needs: [changes, phpunit-oci]
+    needs: [changes-and-matrix, phpunit-oci]
 
     if: always()
 
@@ -209,4 +207,4 @@ jobs:
 
     steps:
       - name: Summary status
-        run: if ${{ needs.changes.outputs.src != 'false' && needs.phpunit-oci.result != 'success' }}; then exit 1; fi
+        run: if ${{ needs.changes-and-matrix.outputs.src != 'false' && needs.phpunit-oci.result != 'success' }}; then exit 1; fi

--- a/workflow-templates/phpunit-pgsql.yml
+++ b/workflow-templates/phpunit-pgsql.yml
@@ -18,22 +18,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  matrix:
-    runs-on: ubuntu-latest-low
-    outputs:
-      php-version: ${{ steps.versions.outputs.php-available-list }}
-      server-max: ${{ steps.versions.outputs.branches-max-list }}
-    steps:
-      - name: Checkout app
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      - name: Get version matrix
-        id: versions
-        uses: nextcloud-libraries/nextcloud-version-matrix@cd0211ffcef1065e2020cd579e4843b8746e7a58 # v1.3.3
-
-  changes:
+  changes-and-matrix:
     runs-on: ubuntu-latest-low
     permissions:
       contents: read
@@ -41,6 +26,8 @@ jobs:
 
     outputs:
       src: ${{ steps.changes.outputs.src }}
+      php-version: ${{ steps.versions.outputs.php-available-list }}
+      server-max: ${{ steps.versions.outputs.branches-max-list }}
 
     steps:
       - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
@@ -60,17 +47,28 @@ jobs:
               - 'composer.json'
               - 'composer.lock'
 
+      - name: Checkout app
+        if: steps.changes.outputs.src != 'false'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Get version matrix
+        if: steps.changes.outputs.src != 'false'
+        id: versions
+        uses: nextcloud-libraries/nextcloud-version-matrix@cd0211ffcef1065e2020cd579e4843b8746e7a58 # v1.3.3
+
   phpunit-pgsql:
     runs-on: ubuntu-latest
 
-    needs: [changes, matrix]
-    if: needs.changes.outputs.src != 'false'
+    needs: changes-and-matrix
+    if: needs.changes-and-matrix.outputs.src != 'false'
 
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ${{ fromJson(needs.matrix.outputs.php-version) }}
-        server-versions: ${{ fromJson(needs.matrix.outputs.server-max) }}
+        php-versions: ${{ fromJson(needs.changes-and-matrix.outputs.php-version) }}
+        server-versions: ${{ fromJson(needs.changes-and-matrix.outputs.server-max) }}
 
     name: PostgreSQL PHP ${{ matrix.php-versions }} Nextcloud ${{ matrix.server-versions }}
 
@@ -192,7 +190,7 @@ jobs:
     permissions:
       contents: none
     runs-on: ubuntu-latest-low
-    needs: [changes, phpunit-pgsql]
+    needs: [changes-and-matrix, phpunit-pgsql]
 
     if: always()
 
@@ -200,4 +198,4 @@ jobs:
 
     steps:
       - name: Summary status
-        run: if ${{ needs.changes.outputs.src != 'false' && needs.phpunit-pgsql.result != 'success' }}; then exit 1; fi
+        run: if ${{ needs.changes-and-matrix.outputs.src != 'false' && needs.phpunit-pgsql.result != 'success' }}; then exit 1; fi

--- a/workflow-templates/phpunit-sqlite.yml
+++ b/workflow-templates/phpunit-sqlite.yml
@@ -18,29 +18,16 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  matrix:
-    runs-on: ubuntu-latest-low
-    outputs:
-      php-version: ${{ steps.versions.outputs.php-available-list }}
-      server-max: ${{ steps.versions.outputs.branches-max-list }}
-    steps:
-      - name: Checkout app
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      - name: Get version matrix
-        id: versions
-        uses: nextcloud-libraries/nextcloud-version-matrix@cd0211ffcef1065e2020cd579e4843b8746e7a58 # v1.3.3
-
-  changes:
+  changes-and-matrix:
     runs-on: ubuntu-latest-low
     permissions:
       contents: read
       pull-requests: read
 
     outputs:
-      src: ${{ steps.changes.outputs.src}}
+      src: ${{ steps.changes.outputs.src }}
+      php-version: ${{ steps.versions.outputs.php-available-list }}
+      server-max: ${{ steps.versions.outputs.branches-max-list }}
 
     steps:
       - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
@@ -60,17 +47,28 @@ jobs:
               - 'composer.json'
               - 'composer.lock'
 
+      - name: Checkout app
+        if: steps.changes.outputs.src != 'false'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Get version matrix
+        if: steps.changes.outputs.src != 'false'
+        id: versions
+        uses: nextcloud-libraries/nextcloud-version-matrix@cd0211ffcef1065e2020cd579e4843b8746e7a58 # v1.3.3
+
   phpunit-sqlite:
     runs-on: ubuntu-latest
 
-    needs: [changes, matrix]
-    if: needs.changes.outputs.src != 'false'
+    needs: changes-and-matrix
+    if: needs.changes-and-matrix.outputs.src != 'false'
 
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ${{ fromJson(needs.matrix.outputs.php-version) }}
-        server-versions: ${{ fromJson(needs.matrix.outputs.server-max) }}
+        php-versions: ${{ fromJson(needs.changes-and-matrix.outputs.php-version) }}
+        server-versions: ${{ fromJson(needs.changes-and-matrix.outputs.server-max) }}
 
     name: SQLite PHP ${{ matrix.php-versions }} Nextcloud ${{ matrix.server-versions }}
 
@@ -181,7 +179,7 @@ jobs:
     permissions:
       contents: none
     runs-on: ubuntu-latest-low
-    needs: [changes, phpunit-sqlite]
+    needs: [changes-and-matrix, phpunit-sqlite]
 
     if: always()
 
@@ -189,4 +187,4 @@ jobs:
 
     steps:
       - name: Summary status
-        run: if ${{ needs.changes.outputs.src != 'false' && needs.phpunit-sqlite.result != 'success' }}; then exit 1; fi
+        run: if ${{ needs.changes-and-matrix.outputs.src != 'false' && needs.phpunit-sqlite.result != 'success' }}; then exit 1; fi


### PR DESCRIPTION
If I am not mistaken, there's no need to have two separate jobs here. When we have no changes, we still need 3 low runners just to detect there are no changes.

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
